### PR TITLE
Detailed interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "clean": "npm run clean:test & npm run clean:dist",
     "prebuild": "npm run clean:dist",
     "build": "node_modules/.bin/tsc",
-    "postbuild": "uglifyjs --screw-ie8 --mangle --compress --in-source-map dist/is.func.js.map --output dist/is.func.min.js --source-map dist/is.func.min.js.map --source-map-url is.func.min.js.map -- dist/is.func.js"
+    "postbuild": "mkdirp dist/bundle && npm run postbuild:max && npm run postbuild:min",
+    "postbuild:max": "uglifyjs --screw-ie8 --beautify --in-source-map dist/is.func.js.map --output dist/bundle/is.func.umd.js --source-map dist/bundle/is.func.umd.js.map --source-map-url is.func.umd.js.map -- dist/is.func.js dist/is.internal.js",
+    "postbuild:min": "uglifyjs --screw-ie8 --mangle --compress --in-source-map dist/is.func.js.map --output dist/bundle/is.func.umd.min.js --source-map dist/bundle/is.func.umd.min.js.map --source-map-url is.func.umd.min.js.map -- dist/is.func.js dist/is.internal.js"
   },
   "repository": {
     "type": "git",
@@ -44,6 +46,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-typescript": "^2.1.7",
+    "mkdirp": "^0.5.1",
     "rimraf": "^2.6.0",
     "typescript": "^2.0.10",
     "uglifyjs": "^2.4.10"

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -3,10 +3,21 @@ import {
   isOptionsArray,
   isOptionsNumber,
   isOptionsObject,
-  isOptionsString,
-  isTypeSchema
+  isOptionsString
 } from './is.interfaces';
+import {
+  isMultipleOf,
+  matchesSchema,
+  isOneOfMultipleTypes,
+  extendObject
+} from './is.internal';
 
+/**
+ * The available data types that `is` can validate for.
+ *
+ * @export
+ * @enum {number}
+ */
 export enum DataType {
   boolean,
   number,
@@ -20,8 +31,9 @@ export enum DataType {
   any
 };
 
-export { isOptions } from './is.interfaces';
-
+/**
+ * Default option set to use within `is`
+ */
 const isDefaultOptions: isOptions = {
   type: DataType.any,
   pattern: '[\s\S]*',
@@ -241,120 +253,4 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
   return true;
 }
 
-/**
- * Tests whether a number is multiple of another number.
- * Keep in mind that Infinity, positive or negative, would return
- * NaN when using it with the modulus operator.
- *
- * @param {number} val
- * @param {number} multipleOf
- * @returns {boolean}
- */
-function isMultipleOf(val: number, multipleOf: number): boolean {
-  return (
-    multipleOf === 0 ||
-    ( val !== Number.NEGATIVE_INFINITY &&
-      val !== Number.POSITIVE_INFINITY &&
-      // Using Math.abs avoids `-0`
-      Math.abs( (val as number) % multipleOf ) === 0
-    )
-  );
-}
-
-/**
- * Tests an object against an object schema.
- *
- * @param {Object} obj
- * @param {(isTypeSchema)} schema
- * @returns {boolean}
- */
-export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): boolean {
-
-  return (( Array.isArray(schema) ? schema : [ schema ] ) as isTypeSchema[])
-    .some( s => {
-
-      const _type = s.type ? s.type : DataType.any; // Use any if no type is present.
-      const _typeOptions = ( is(s.options, DataType.object) ? s.options : {} );
-      /** Test for type */
-      const _typeValid = isOneOfMultipleTypes( _val, _type, _typeOptions );
-
-      /** Test for properties */
-      let _propsValid = true;
-      let _reqdValid = true;
-      const _props = ( is(s.props, DataType.object) ? Object.keys(s.props) : [] );
-      if ( _props.length > 0 ) {
-
-        /** Get all keys that are required from the schema */
-        /** Test for `required` props */
-        _reqdValid = _props
-          .filter( p => s.props[p].required === true )
-          .every( r => _val[r] !== undefined );
-
-        /**
-         * Iterate over the `props` keys
-         * If `obj` has `p` property, call `matchesSchema` on that property of the object.
-         * The schema will be the value of `p` on the schema props.
-         *
-         * NOTE: if `p` is not in object, we don't validate; however, if it's required,
-         * it'll be caught because that's being validated above
-         */
-        _propsValid = _props
-          .every( p => ( _val !== undefined && _val[p] !== undefined ? matchesSchema(_val[p], s.props[p]) : true ) );
-      }
-
-      /** Test items if `array` */
-      let _itemsValid = true;
-      if ( _type === DataType.array && _typeValid && s.items !== undefined ) {
-        _itemsValid = (_val as any[]).every( i => matchesSchema(i, s.items) );
-      }
-
-      return _typeValid && _reqdValid && _propsValid && _itemsValid;
-    });
-}
-
-/**
- * Tests a value against a series of DataTypes (one or more).
- *
- * @param {*} val
- * @param {(DataType|DataType[])} type
- * @param {isOptions} [options]
- * @returns {boolean}
- */
-export function isOneOfMultipleTypes(val: any, type: DataType|DataType[], options?: isOptions): boolean {
-  /** Coerce `DataType` into an array */
-  let types = ( Array.isArray(type) ? type : [ type ] );
-
-  /** Check for presence of `any` */
-  if ( types.indexOf(DataType.any) !== -1 ) return true;
-
-  /** Filter out non-`DataType` items */
-  types = types.filter( v => typeof v === 'number' && (DataType as any).hasOwnProperty(v) );
-
-  /** Test `val` prop against type validation */
-  return ( types.length === 0 ? false : types.some( n => is(val, n, options) ) );
-}
-
-/**
- * Extends an object with the *enumerable* and *own* properties of one or more source objects,
- * similar to Object.assign.
- *
- * @param dest The object which will have properties copied to it.
- * @param sources The source objects from which properties will be copied.
- */
-export function extendObject(dest: any, ...sources: any[]): any {
-  if (dest == null) {
-    throw TypeError('Cannot convert undefined or null to object');
-  }
-
-  for (let source of sources) {
-    if (source != null) {
-      for (let key in source) {
-        if (source.hasOwnProperty(key)) {
-          dest[key] = source[key];
-        }
-      }
-    }
-  }
-
-  return dest;
-}
+export { isOptions } from './is.interfaces';

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -1,28 +1,26 @@
+import {
+  isOptions,
+  isOptionsArray,
+  isOptionsNumber,
+  isOptionsObject,
+  isOptionsString,
+  isTypeSchema
+} from './is.interfaces';
 
-export enum DataType { boolean, number, integer, natural, string, function, object, array, undefined, any };
+export enum DataType {
+  boolean,
+  number,
+  integer,
+  natural,
+  string,
+  function,
+  object,
+  array,
+  undefined,
+  any
+};
 
-export interface isTypeSchema {
-  type?: DataType|DataType[]
-  props?: ({ [k: string]: isTypeSchema });
-  items?: isTypeSchema|isTypeSchema[];
-  required?: boolean;
-  options?: isOptions;
-}
-
-export interface isOptions {
-  type?: DataType|DataType[];
-  pattern?: string;
-  patternFlags?: string;
-  exclEmpty?: boolean;
-  schema?: isTypeSchema|isTypeSchema[];
-  allowNull?: boolean;
-  arrayAsObject?: boolean;
-  min?: number;
-  max?: number;
-  exclMin?: number;
-  exclMax?: number;
-  multipleOf?: number;
-}
+export { isOptions } from './is.interfaces';
 
 const isDefaultOptions: isOptions = {
   type: DataType.any,
@@ -142,10 +140,10 @@ const isDefaultOptions: isOptions = {
  */
 export function is(val: undefined, type: DataType): boolean;
 export function is(val: boolean, type: DataType): boolean;
-export function is(val: number, type: DataType, options?: { min?: number, max?:number, exclMin?: number, exclMax?: number, multipleOf?: number }): boolean;
-export function is(val: string, type: DataType, options?: { pattern?: string, patternFlags?: string, exclEmpty?: boolean }): boolean;
-export function is(val: any[], type: DataType, options?: { schema?: isTypeSchema|isTypeSchema[], type?: DataType|DataType[], min?: number, max?:number, exclMin?: number, exclMax?: number }): boolean;
-export function is(val: Object, type: DataType, options?: { schema?: isTypeSchema|isTypeSchema[], allowNull?: boolean, arrayAsObject?: boolean }): boolean;
+export function is(val: number, type: DataType, options?: isOptionsNumber): boolean;
+export function is(val: string, type: DataType, options?: isOptionsString): boolean;
+export function is(val: any[], type: DataType, options?: isOptionsArray): boolean;
+export function is(val: Object, type: DataType, options?: isOptionsObject): boolean;
 export function is(val: any, type: DataType, options?: isOptions): boolean {
 
   /** Combine passed options with default options. */

--- a/src/is.interfaces.ts
+++ b/src/is.interfaces.ts
@@ -1,0 +1,97 @@
+import { DataType } from './is.func';
+
+/**
+ * A descriptive model of what an object is expected to be.
+ *
+ * @export
+ * @interface isTypeSchema
+ */
+export interface isTypeSchema {
+  type?: DataType|DataType[]
+  props?: ({ [k: string]: isTypeSchema });
+  items?: isTypeSchema|isTypeSchema[];
+  required?: boolean;
+  options?: isOptions;
+}
+
+/**
+ * The entirety of the options available to use with `is`
+ *
+ * @export
+ * @interface isOptions
+ * @extends {isOptionsNumber}
+ * @extends {isOptionsString}
+ * @extends {isOptionsArray}
+ * @extends {isOptionsObject}
+ */
+export interface isOptions extends isOptionsNumber, isOptionsString, isOptionsArray, isOptionsObject {}
+
+/**
+ * The options available to use on a number type use case with `is`
+ *
+ * @export
+ * @interface isOptionsNumber
+ * @extends {isOptionsMinMax}
+ */
+export interface isOptionsNumber extends isOptionsMinMax {
+  multipleOf?: number;
+}
+
+/**
+ * The options available to use on a string type use case with `is`
+ *
+ * @export
+ * @interface isOptionsString
+ */
+export interface isOptionsString {
+  pattern?: string;
+  patternFlags?: string;
+  exclEmpty?: boolean;
+}
+
+/**
+ * The options available to use on an Array type use case with `is`
+ *
+ * @export
+ * @interface isOptionsArray
+ * @extends {isOptionsMinMax}
+ * @extends {isOptionsSchema}
+ */
+export interface isOptionsArray extends isOptionsMinMax, isOptionsSchema {
+  type?: DataType|DataType[];
+}
+
+/**
+ * The options available to use on an Object type use case with `is`
+ *
+ * @export
+ * @interface isOptionsObject
+ * @extends {isOptionsSchema}
+ */
+export interface isOptionsObject extends isOptionsSchema {
+  allowNull?: boolean;
+  arrayAsObject?: boolean;
+}
+
+/**
+ * A shared interface for those option sets that use the `schema` options
+ *
+ * @export
+ * @interface isOptionsSchema
+ */
+export interface isOptionsSchema {
+  schema?: isTypeSchema|isTypeSchema[];
+}
+
+/**
+ * A shared interface for those option sets that use the `min` and `max` options
+ *
+ * @export
+ * @interface isOptionsMinMax
+ */
+export interface isOptionsMinMax {
+  min?: number;
+  max?:number;
+  exclMin?: number;
+  exclMax?: number;
+}

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -1,0 +1,120 @@
+import { is, DataType } from './is.func';
+import { isOptions, isTypeSchema } from './is.interfaces';
+
+/**
+ * Tests whether a number is multiple of another number.
+ * Keep in mind that Infinity, positive or negative, would return
+ * NaN when using it with the modulus operator.
+ *
+ * @param {number} val
+ * @param {number} multipleOf
+ * @returns {boolean}
+ */
+export function isMultipleOf(val: number, multipleOf: number): boolean {
+  return (
+    multipleOf === 0 ||
+    ( val !== Number.NEGATIVE_INFINITY &&
+      val !== Number.POSITIVE_INFINITY &&
+      // Using Math.abs avoids `-0`
+      Math.abs( (val as number) % multipleOf ) === 0
+    )
+  );
+}
+
+/**
+ * Tests an object against an object schema.
+ *
+ * @param {Object} obj
+ * @param {(isTypeSchema)} schema
+ * @returns {boolean}
+ */
+export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): boolean {
+
+  return (( Array.isArray(schema) ? schema : [ schema ] ) as isTypeSchema[])
+    .some( s => {
+
+      const _type = s.type ? s.type : DataType.any; // Use any if no type is present.
+      const _typeOptions = ( is(s.options, DataType.object) ? s.options : {} );
+      /** Test for type */
+      const _typeValid = isOneOfMultipleTypes( _val, _type, _typeOptions );
+
+      /** Test for properties */
+      let _propsValid = true;
+      let _reqdValid = true;
+      const _props = ( is(s.props, DataType.object) ? Object.keys(s.props) : [] );
+      if ( _props.length > 0 ) {
+
+        /** Get all keys that are required from the schema */
+        /** Test for `required` props */
+        _reqdValid = _props
+          .filter( p => s.props[p].required === true )
+          .every( r => _val[r] !== undefined );
+
+        /**
+         * Iterate over the `props` keys
+         * If `obj` has `p` property, call `matchesSchema` on that property of the object.
+         * The schema will be the value of `p` on the schema props.
+         *
+         * NOTE: if `p` is not in object, we don't validate; however, if it's required,
+         * it'll be caught because that's being validated above
+         */
+        _propsValid = _props
+          .every( p => ( _val !== undefined && _val[p] !== undefined ? matchesSchema(_val[p], s.props[p]) : true ) );
+      }
+
+      /** Test items if `array` */
+      let _itemsValid = true;
+      if ( _type === DataType.array && _typeValid && s.items !== undefined ) {
+        _itemsValid = (_val as any[]).every( i => matchesSchema(i, s.items) );
+      }
+
+      return _typeValid && _reqdValid && _propsValid && _itemsValid;
+    });
+}
+
+/**
+ * Tests a value against a series of DataTypes (one or more).
+ *
+ * @param {*} val
+ * @param {(DataType|DataType[])} type
+ * @param {isOptions} [options]
+ * @returns {boolean}
+ */
+export function isOneOfMultipleTypes(val: any, type: DataType|DataType[], options?: isOptions): boolean {
+  /** Coerce `DataType` into an array */
+  let types = ( Array.isArray(type) ? type : [ type ] );
+
+  /** Check for presence of `any` */
+  if ( types.indexOf(DataType.any) !== -1 ) return true;
+
+  /** Filter out non-`DataType` items */
+  types = types.filter( v => typeof v === 'number' && (DataType as any).hasOwnProperty(v) );
+
+  /** Test `val` prop against type validation */
+  return ( types.length === 0 ? false : types.some( n => is(val, n, options) ) );
+}
+
+/**
+ * Extends an object with the *enumerable* and *own* properties of one or more source objects,
+ * similar to Object.assign.
+ *
+ * @param dest The object which will have properties copied to it.
+ * @param sources The source objects from which properties will be copied.
+ */
+export function extendObject(dest: any, ...sources: any[]): any {
+  if (dest == null) {
+    throw TypeError('Cannot convert undefined or null to object');
+  }
+
+  for (let source of sources) {
+    if (source != null) {
+      for (let key in source) {
+        if (source.hasOwnProperty(key)) {
+          dest[key] = source[key];
+        }
+      }
+    }
+  }
+
+  return dest;
+}

--- a/src/spec/extendObject.spec.ts
+++ b/src/spec/extendObject.spec.ts
@@ -1,4 +1,4 @@
-import { extendObject } from '../is.func';
+import { extendObject } from '../is.internal';
 
 describe('extendObject', () => {
   it('should extend an object', () => {

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -1,4 +1,5 @@
-import { is, DataType, isOptions, matchesSchema } from '../is.func';
+import { is, DataType, isOptions } from '../is.func';
+import { matchesSchema } from '../is.internal';
 import * as TC from './test-cases/test-cases.spec';
 
 describe('`is` and `matchesSchema`', () => {

--- a/src/spec/isOneOfMultipleTypes.spec.ts
+++ b/src/spec/isOneOfMultipleTypes.spec.ts
@@ -1,4 +1,5 @@
-import { DataType, isOneOfMultipleTypes } from '../is.func';
+import { DataType } from '../is.func';
+import { isOneOfMultipleTypes } from '../is.internal';
 import { aggregateUseCases } from './test-cases/test-cases.spec';
 
 const invalidTypeValues = [

--- a/src/spec/matchesSchema.spec.ts
+++ b/src/spec/matchesSchema.spec.ts
@@ -1,5 +1,6 @@
-import { DataType, matchesSchema } from '../is.func';
+import { DataType } from '../is.func';
 import { isTypeSchema } from '../is.interfaces';
+import { matchesSchema } from '../is.internal';
 
 describe(`\`matchesSchema\` function`, () => {
 

--- a/src/spec/matchesSchema.spec.ts
+++ b/src/spec/matchesSchema.spec.ts
@@ -1,4 +1,5 @@
-import { DataType, isTypeSchema, matchesSchema } from '../is.func';
+import { DataType, matchesSchema } from '../is.func';
+import { isTypeSchema } from '../is.interfaces';
 
 describe(`\`matchesSchema\` function`, () => {
 


### PR DESCRIPTION
1. **feat: enhance interface detail**

At a glance the type structure of `is` together with `isOptions` wasn’t very explicit. Interfaces have now been broken out into their own file to show a little bit more how the model of `isOptions` is formed with the added benefit of making the `is` type more clear.

2. **feat: clean up default exposed API**

There were a multitude of items being exposed by default through the main package file. Aiming to clarify the main utilities being exposed by this package, now only `is`, `isOptions` and `DataType` are being exposed through the main file, which makes the package intent much clearer, in my opinion.

It’s worth noting, however, that the remainder of the functions and interfaces are still accessible if needed.

3. **build: generate beautified and a minified umd bundles in `dist/bundle`**