### PR TITLE
feat(build): use `webpack` to output UMD bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "clean": "npm run clean:test & npm run clean:dist",
     "prebuild": "npm run clean:dist",
     "build": "node_modules/.bin/tsc",
-    "postbuild": "mkdirp dist/bundle && npm run postbuild:max && npm run postbuild:min",
-    "postbuild:max": "uglifyjs --screw-ie8 --beautify --in-source-map dist/is.func.js.map --output dist/bundle/is.func.umd.js --source-map dist/bundle/is.func.umd.js.map --source-map-url is.func.umd.js.map -- dist/is.func.js dist/is.internal.js",
-    "postbuild:min": "uglifyjs --screw-ie8 --mangle --compress --in-source-map dist/is.func.js.map --output dist/bundle/is.func.umd.min.js --source-map dist/bundle/is.func.umd.min.js.map --source-map-url is.func.umd.min.js.map -- dist/is.func.js dist/is.internal.js"
+    "postbuild": "node_modules/.bin/webpack --env.min && node_modules/.bin/webpack"
   },
   "repository": {
     "type": "git",
@@ -46,9 +44,9 @@
     "karma-jasmine": "^1.1.0",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-typescript": "^2.1.7",
-    "mkdirp": "^0.5.1",
     "rimraf": "^2.6.0",
+    "ts-loader": "^2.0.0",
     "typescript": "^2.0.10",
-    "uglifyjs": "^2.4.10"
+    "webpack": "^2.2.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const webpack = require('webpack');
+
+const SRC_DIR = path.resolve(__dirname, './src');
+const DIST_DIR = path.resolve(__dirname, './dist');
+
+module.exports = function(_env) {
+
+  const env = {
+    min: ( _env && _env.min ?  true : false )
+  };
+
+  const uglifyOptions = (
+    env.min ?
+    {
+      compress: { warnings: false },
+      output: { comments: false },
+      sourceMap: true,
+      comments: false,
+      mangle: true
+    } :
+    {
+      compress: false,
+      output: { comments: false },
+      sourceMap: true,
+      comments: false,
+      mangle: false,
+      beautify: true
+    }
+  )
+
+  return {
+    context: SRC_DIR,
+    devtool: 'source-map',
+    entry: {
+      'is.func': path.resolve(SRC_DIR, './is.func.ts')
+    },
+    output: {
+      path: path.resolve(DIST_DIR, './bundle'),
+      filename: `[name].umd${( env.min ? '.min' : '' )}.js`,
+      sourceMapFilename: '[file].map',
+      libraryTarget: 'umd',
+      pathinfo: false
+    },
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          loader: 'ts-loader',
+          options: {
+            compilerOptions: {
+              module: 'ES2015',
+              declaration: false
+            }
+          }
+        }
+      ]
+    },
+    plugins: [
+      new webpack.LoaderOptionsPlugin({ minimize: ( env.min ) }),
+      new webpack.optimize.UglifyJsPlugin(uglifyOptions)
+    ],
+    resolve: {
+      extensions: ['.tsx', '.ts', '.js']
+    },
+  }
+};


### PR DESCRIPTION
Inside `dist` the UMD bundles will still be generated in a `bundle` subdirectory. Unminified `is.func.umd.js` and minified `is.func.umd.min.js` versions will be created, each with source maps respectively.