### PR TITLE
Incremental validation improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "karma-typescript": "^2.1.7",
     "rimraf": "^2.6.0",
     "ts-loader": "^2.0.0",
-    "typescript": "^2.0.10",
+    "typescript": "~2.1.0",
     "webpack": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "is-datatype",
   "version": "0.1.1",
   "description": "Type validation function meant to go beyond the use cases of operators such as `typeof` by providing a few more common pseudo data types to check agasint, as well as a certain degree of options to validate against as well",
-  "main": "dist/is.func.js",
+  "main": "dist/bundle/is.func.umd.min.js",
   "types": "dist/is.func.d.ts",
   "scripts": {
     "pretest": "npm run clean:test",

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -172,7 +172,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     if ( !isMultipleOf(_options.multipleOf as number, 1) ) return false;
 
     let numOptions: isOptions = { multipleOf: ( _options.multipleOf === 0 ? 1 : _options.multipleOf ) };
-    if ( type === DataType.natural ) numOptions.min = ( _options.min >= 0 ? _options.min : 0 );
+    if ( type === DataType.natural ) numOptions.min = ( _options.min !== undefined && _options.min >= 0 ? _options.min : 0 );
 
     return is((val as number), DataType.number, extendObject({}, _options, numOptions) );
   };
@@ -219,10 +219,10 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     return (
       (val as any[]).every( n => isOneOfMultipleTypes(n, _options.type as DataType|DataType[]) ) &&
       ( _options.schema === null || matchesSchema(val, _options.schema as isTypeSchema|isTypeSchema[]) ) &&
-      (val as any[]).length >= _options.min &&
-      (val as any[]).length <= _options.max &&
-      ( _options.exclMin === Number.NEGATIVE_INFINITY || (val as any[]).length > _options.exclMin ) &&
-      ( _options.exclMax === Number.POSITIVE_INFINITY || (val as any[]).length < _options.exclMax )
+      ( _options.min !== undefined && (val as any[]).length >= _options.min ) &&
+      ( _options.max !== undefined && (val as any[]).length <= _options.max ) &&
+      ( _options.exclMin === Number.NEGATIVE_INFINITY || ( _options.exclMin !== undefined && (val as any[]).length > _options.exclMin) ) &&
+      ( _options.exclMax === Number.POSITIVE_INFINITY || ( _options.exclMax !== undefined && (val as any[]).length < _options.exclMax) )
     );
   }
 
@@ -243,10 +243,10 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if( type === DataType.number) {
     return (
-      (val as number) >= _options.min &&
-      (val as number) <= _options.max &&
-      ( _options.exclMin === Number.NEGATIVE_INFINITY || (val as number) > _options.exclMin ) &&
-      ( _options.exclMax === Number.POSITIVE_INFINITY || (val as number) < _options.exclMax ) &&
+      ( _options.min !== undefined && (val as number) >= _options.min ) &&
+      ( _options.max !== undefined && (val as number) <= _options.max ) &&
+      ( _options.exclMin === Number.NEGATIVE_INFINITY || ( _options.exclMin !== undefined && (val as number) > _options.exclMin) ) &&
+      ( _options.exclMax === Number.POSITIVE_INFINITY || ( _options.exclMax !== undefined && (val as number) < _options.exclMax) ) &&
       isMultipleOf(val, _options.multipleOf as number)
     );
   }

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -4,13 +4,14 @@ import {
   isOptionsNumber,
   isOptionsObject,
   isOptionsString,
-  isTypeSchema
+  isTypeSchema,
 } from './is.interfaces';
 import {
   isMultipleOf,
   matchesSchema,
   isOneOfMultipleTypes,
-  extendObject
+  extendObject,
+  isValidOptions,
 } from './is.internal';
 
 /**
@@ -159,6 +160,11 @@ export function is(val: string, type: DataType, options?: isOptionsString): bool
 export function is(val: any[], type: DataType, options?: isOptionsArray): boolean;
 export function is(val: Object, type: DataType, options?: isOptionsObject): boolean;
 export function is(val: any, type: DataType, options?: isOptions): boolean {
+
+  /** Check options */
+  if(options !== undefined && !isValidOptions(options as isOptions)) {
+    throw `Provided invalid options object when testing for ${JSON.stringify(val)}: ${JSON.stringify(options)}`;
+  }
 
   /** Combine passed options with default options. */
   const _options: isOptions = extendObject({}, isDefaultOptions, options);

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -3,7 +3,8 @@ import {
   isOptionsArray,
   isOptionsNumber,
   isOptionsObject,
-  isOptionsString
+  isOptionsString,
+  isTypeSchema
 } from './is.interfaces';
 import {
   isMultipleOf,
@@ -104,7 +105,7 @@ const isDefaultOptions: isOptions = {
  *
  * ### Array options
  *
- * * `type`: `DataType|DataType[]`
+ * * `type`: `DataType|Array<DataType>`
  * * `min`: `number`
  * * `max`: `number`
  * * `exclMin`: `number`
@@ -146,8 +147,9 @@ const isDefaultOptions: isOptions = {
  *
  * * Use cases for `symbol`
  *
- * @param {any} val  The value to test for.
- * @param {DataType} type  One of the DataType enum values
+ * @param {*} val - The value to test for.
+ * @param {DataType} type - One of the DataType enum values
+ * @param {isOptions} [options]
  * @returns {boolean}  Whether the validation is true or not
  */
 export function is(val: undefined, type: DataType): boolean;
@@ -167,7 +169,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if ( type === DataType.integer || type === DataType.natural ) {
     /** Immediately return false is `multipleOf` is passed, but it's not a multiple of 1. */
-    if ( !isMultipleOf(_options.multipleOf, 1) ) return false;
+    if ( !isMultipleOf(_options.multipleOf as number, 1) ) return false;
 
     let numOptions: isOptions = { multipleOf: ( _options.multipleOf === 0 ? 1 : _options.multipleOf ) };
     if ( type === DataType.natural ) numOptions.min = ( _options.min >= 0 ? _options.min : 0 );
@@ -204,8 +206,8 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if ( type === DataType.object ) {
     return (
-      ( !Array.isArray(val) || _options.arrayAsObject ) &&
-      ( _options.schema === null || matchesSchema(val, _options.schema) )
+      ( !Array.isArray(val) || _options.arrayAsObject as boolean ) &&
+      ( _options.schema === null || matchesSchema(val, _options.schema as isTypeSchema|isTypeSchema[]) )
     );
   }
 
@@ -215,8 +217,8 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if ( type === DataType.array) {
     return (
-      (val as any[]).every( n => isOneOfMultipleTypes(n, _options.type) ) &&
-      ( _options.schema === null || matchesSchema(val, _options.schema) ) &&
+      (val as any[]).every( n => isOneOfMultipleTypes(n, _options.type as DataType|DataType[]) ) &&
+      ( _options.schema === null || matchesSchema(val, _options.schema as isTypeSchema|isTypeSchema[]) ) &&
       (val as any[]).length >= _options.min &&
       (val as any[]).length <= _options.max &&
       ( _options.exclMin === Number.NEGATIVE_INFINITY || (val as any[]).length > _options.exclMin ) &&
@@ -228,7 +230,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
   if ( type === DataType.string ) {
     return (
       ( !((val as string).length === 0 ) || !_options.exclEmpty ) &&
-      ( new RegExp(_options.pattern, _options.patternFlags) ).test(val)
+      ( new RegExp(_options.pattern as string, _options.patternFlags) ).test(val)
     );
   }
 
@@ -245,7 +247,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
       (val as number) <= _options.max &&
       ( _options.exclMin === Number.NEGATIVE_INFINITY || (val as number) > _options.exclMin ) &&
       ( _options.exclMax === Number.POSITIVE_INFINITY || (val as number) < _options.exclMax ) &&
-      isMultipleOf(val, _options.multipleOf)
+      isMultipleOf(val, _options.multipleOf as number)
     );
   }
 

--- a/src/is.interfaces.ts
+++ b/src/is.interfaces.ts
@@ -7,7 +7,7 @@ import { DataType } from './is.func';
  * @interface isTypeSchema
  */
 export interface isTypeSchema {
-  type?: DataType|DataType[]
+  type?: DataType|DataType[];
   props?: ({ [k: string]: isTypeSchema });
   items?: isTypeSchema|isTypeSchema[];
   required?: boolean;
@@ -80,7 +80,7 @@ export interface isOptionsObject extends isOptionsSchema {
  * @interface isOptionsSchema
  */
 export interface isOptionsSchema {
-  schema?: isTypeSchema|isTypeSchema[];
+  schema?: isTypeSchema|isTypeSchema[]|null;
 }
 
 /**
@@ -91,7 +91,7 @@ export interface isOptionsSchema {
  */
 export interface isOptionsMinMax {
   min?: number;
-  max?:number;
+  max?: number;
   exclMin?: number;
   exclMax?: number;
 }

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -109,10 +109,10 @@ export function isOneOfMultipleTypes(val: any, type: DataType|DataType[], option
   if ( types.indexOf(DataType.any) !== -1 ) return true;
 
   /** Filter out non-`DataType` items */
-  types = types.filter( v => typeof v === 'number' && (DataType as any).hasOwnProperty(v) );
+  types = types.filter( v => is(v, DataType.number) && (DataType as any).hasOwnProperty(v) );
 
   /** Test `val` prop against type validation */
-  return ( types.length === 0 ? false : types.some( n => is(val, n, options) ) );
+  return ( types.length > 0 ? types.some( n => is(val, n, options) ) : false );
 }
 
 /**

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -24,48 +24,69 @@ export function isMultipleOf(val: number, multipleOf: number): boolean {
 /**
  * Tests an object against an object schema.
  *
- * @param {Object} obj
- * @param {(isTypeSchema)} schema
+ * @export
+ * @param {*} _val
+ * @param {(isTypeSchema|Array<isTypeSchema>)} schema
  * @returns {boolean}
  */
 export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): boolean {
 
   return (( Array.isArray(schema) ? schema : [ schema ] ) as isTypeSchema[])
-    .some( s => {
+    /** Test every schema until at least one of them matches */
+    .some( (s: isTypeSchema) => {
 
-      const _type = s.type ? s.type : DataType.any; // Use any if no type is present.
-      const _typeOptions = ( is(s.options, DataType.object) ? s.options : {} );
-      /** Test for type */
+      /** Get type. Use `any` if none is present */
+      const _type: DataType|DataType[] = s.type ? s.type : DataType.any;
+
+      /** Get the options, if any. Use objecct literal if not available. */
+      const _typeOptions: isOptions = ( is(s.options as isOptions, DataType.object) ? s.options : {} ) as isOptions;
+
+      /** Test if any of the data types matches */
       const _typeValid = isOneOfMultipleTypes( _val, _type, _typeOptions );
 
-      /** Test for properties */
+      /**
+       * Whether the properties match what's reflected in the schema.
+       * Initially assumed as `true`.
+       */
       let _propsValid = true;
-      let _reqdValid = true;
-      const _props = ( is(s.props, DataType.object) ? Object.keys(s.props) : [] );
-      if ( _props.length > 0 ) {
 
-        /** Get all keys that are required from the schema */
-        /** Test for `required` props */
-        _reqdValid = _props
-          .filter( p => s.props[p].required === true )
+      /**
+       * Whether the required properties are present.
+       * Initially assumed as `true`.
+       */
+      let _reqdValid = true;
+
+      /** Extract the properties to test for into an array */
+      const _propKeys: string[] = ( is(s.props as isOptions, DataType.object) ? Object.keys(s.props) : [] );
+
+      /** Begin tests relevat to properties */
+      if ( _propKeys.length > 0 ) {
+
+        /**
+         * Get all keys that are required from the schema,
+         * and then test for required propertes.
+         */
+        _reqdValid = _propKeys
+          .filter( p => s.props && s.props[p] && s.props[p].required === true )
           .every( r => _val[r] !== undefined );
 
         /**
-         * Iterate over the `props` keys
-         * If `obj` has `p` property, call `matchesSchema` on that property of the object.
-         * The schema will be the value of `p` on the schema props.
+         * Iterate over the property keys.
          *
-         * NOTE: if `p` is not in object, we don't validate; however, if it's required,
-         * it'll be caught because that's being validated above
+         * If the subject has the property we're seeking,
+         * `matchesSchema` is called on that property.
+         *
+         * If `p`, the property, is not an object, it won't be validated against.
+         * However, if it was required, that will have been caught by the check above.
          */
-        _propsValid = _props
-          .every( p => ( _val !== undefined && _val[p] !== undefined ? matchesSchema(_val[p], s.props[p]) : true ) );
+        _propsValid = _propKeys
+          .every( p => ( !!s.props && _val !== undefined && _val[p] !== undefined ? matchesSchema(_val[p], s.props[p]) : true ) );
       }
 
       /** Test items if `array` */
       let _itemsValid = true;
       if ( _type === DataType.array && _typeValid && s.items !== undefined ) {
-        _itemsValid = (_val as any[]).every( i => matchesSchema(i, s.items) );
+        _itemsValid = (_val as any[]).every( i => matchesSchema(i, s.items as isTypeSchema|isTypeSchema[]) );
       }
 
       return _typeValid && _reqdValid && _propsValid && _itemsValid;
@@ -76,7 +97,7 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
  * Tests a value against a series of DataTypes (one or more).
  *
  * @param {*} val
- * @param {(DataType|DataType[])} type
+ * @param {(DataType|Array<DataType>)} type
  * @param {isOptions} [options]
  * @returns {boolean}
  */
@@ -98,8 +119,10 @@ export function isOneOfMultipleTypes(val: any, type: DataType|DataType[], option
  * Extends an object with the *enumerable* and *own* properties of one or more source objects,
  * similar to Object.assign.
  *
- * @param dest The object which will have properties copied to it.
- * @param sources The source objects from which properties will be copied.
+ * @export
+ * @param {*} dest
+ * @param {...Array<any>} sources
+ * @returns {*}
  */
 export function extendObject(dest: any, ...sources: any[]): any {
   if (dest == null) {

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -263,6 +263,80 @@ describe('`is` and `matchesSchema`', () => {
 
   });
 
+  describe('`options` validation', () => {
+
+    it('should detect invalid values assigned to `type`', () => {
+      expect( () => is([''], DataType.array, { type: DataType.string }) ).not.toThrow();
+      expect( () => is([''], DataType.array, { type: DataType[DataType.string] } as any) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `pattern`', () => {
+      expect( () => is('hello', DataType.string, { pattern: 'hello' }) ).not.toThrow();
+      expect( () => is('hello', DataType.string, { pattern: /(hello)/ } as any) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `patternFlags`', () => {
+      expect( () => is('hello', DataType.string, { patternFlags: '' }) ).not.toThrow();
+      expect( () => is('hello', DataType.string, { patternFlags: 'ig' }) ).not.toThrow();
+      expect( () => is('hello', DataType.string, { patternFlags: null } as any) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `exclEmpty`', () => {
+      expect( () => is('hello', DataType.string, { exclEmpty: true }) ).not.toThrow();
+      expect( () => is('hello', DataType.string, { exclEmpty: 'true' } as any) ).toThrow();
+      expect( () => is('hello', DataType.string, { exclEmpty: 1 } as any) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `schema`', () => {
+      expect( () => is({}, DataType.object, { schema: null }) ).not.toThrow();
+      expect( () => is({}, DataType.object, { schema: {} }) ).not.toThrow();
+      expect( () => is({}, DataType.object, { schema: undefined } as any) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `allowNull`', () => {
+      expect( () => is(null, DataType.object, { allowNull: true }) ).not.toThrow();
+      expect( () => is(null, DataType.object, { allowNull: 'true' } as any) ).toThrow();
+      expect( () => is(null, DataType.object, { allowNull: 1 } as any) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `arrayAsObject`', () => {
+      expect( () => is([''], DataType.object, { arrayAsObject: true }) ).not.toThrow();
+      expect( () => is([''], DataType.object, { arrayAsObject: 'true' } as any) ).toThrow();
+      expect( () => is([''], DataType.object, { arrayAsObject: 1 } as any) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `min`', () => {
+      expect( () => is(100, DataType.number, { min: 0 }) ).not.toThrow();
+      expect( () => is(100, DataType.number, { min: '0' } as any) ).toThrow();
+      expect( () => is(100, DataType.number, { min: NaN }) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `max`', () => {
+      expect( () => is(100, DataType.number, { max: 0 }) ).not.toThrow();
+      expect( () => is(100, DataType.number, { max: '0' } as any) ).toThrow();
+      expect( () => is(100, DataType.number, { max: NaN }) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `exclMin`', () => {
+      expect( () => is(100, DataType.number, { exclMin: 0 }) ).not.toThrow();
+      expect( () => is(100, DataType.number, { exclMin: '0' } as any) ).toThrow();
+      expect( () => is(100, DataType.number, { exclMin: NaN }) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `exclMax`', () => {
+      expect( () => is(100, DataType.number, { exclMax: 0 }) ).not.toThrow();
+      expect( () => is(100, DataType.number, { exclMax: '0' } as any) ).toThrow();
+      expect( () => is(100, DataType.number, { exclMax: NaN }) ).toThrow();
+    });
+
+    it('should detect invalid values assigned to `multipleOf`', () => {
+      expect( () => is(100, DataType.number, { multipleOf: 0 }) ).not.toThrow();
+      expect( () => is(100, DataType.number, { multipleOf: '0' } as any) ).toThrow();
+      expect( () => is(100, DataType.number, { multipleOf: NaN }) ).toThrow();
+    });
+
+  });
+
 });
 
 // Symbols

--- a/src/spec/test-cases/non-schema.spec.ts
+++ b/src/spec/test-cases/non-schema.spec.ts
@@ -1,4 +1,5 @@
 import { DataType } from '../../is.func';
+import { isOptions } from '../../is.func';
 
 export const validNumberUseCases = [
   37,
@@ -97,6 +98,9 @@ export const numberRangeUseCases = [
   { test: -3.13,  options: { exclMin: -3.13 },              expect: false },
   { test: -3.15,  options: { min: -3.15, exclMin: -3.15 },  expect: false },
   { test: -3.13,  options: { min: -3.13, exclMin: -3.13 },  expect: false },
+
+  // With inconsequential option
+  { test: -3.13,  options: { min: -3.13, exclMin: -3.13, someOtherProp: true },  expect: false },
 ];
 
 export const multipleOfUseCases = [
@@ -117,7 +121,10 @@ export const multipleOfUseCases = [
   { test: -2,       options: { multipleOf: -2 },    expect: true },
   { test: 6.28,     options: { multipleOf: 3.14 },  expect: true },
   { test: -6.28,    options: { multipleOf: 3.14 },  expect: true },
-  { test: 6.28,     options: { multipleOf: -3.14 }, expect: true }
+  { test: 6.28,     options: { multipleOf: -3.14 }, expect: true },
+
+  // With inconsequential option
+  { test: 6.28,     options: { multipleOf: -3.14, someOtherProp: true }, expect: true }
 ];
 
 export const integerUseCases = [
@@ -136,7 +143,10 @@ export const integerUseCases = [
   { test: -2048,          options: { multipleOf: -512 },  expect: true },
   { test: 3.14,           options: { multipleOf: 2 },     expect: false },
   { test: Math.sqrt(2),   options: { multipleOf: 2 },     expect: false },
-  { test: 3.14,           options: { multipleOf: 3.14 },  expect: false }
+  { test: 3.14,           options: { multipleOf: 3.14 },  expect: false },
+
+  // With inconsequential option
+  { test: 3.14,           options: { multipleOf: 3.14, someOtherProp: true },  expect: false }
 ];
 
 export const naturalUseCases = [
@@ -163,7 +173,10 @@ export const naturalUseCases = [
   { test: 4,              options: { max: 3 },  expect: false },
   { test: 0,              options: { max: 0 },  expect: true },
   { test: 0,              options: { exclMin: 0 },  expect: false },
-  { test: 0,              options: { exclMax: 0 },  expect: false }
+  { test: 0,              options: { exclMax: 0 },  expect: false },
+
+  // With inconsequential option
+  { test: 0,              options: { exclMax: 0, someOtherProp: true },  expect: false }
 ];
 
 export const validStringUseCases = [
@@ -181,7 +194,10 @@ export const stringPatternUseCases = [
   { test: 'hello world!',   options: { pattern: 'world', patternFlags: 'g' },   expect: true },
   { test: 'HELLO WORLD!',   options: { pattern: 'world' },                      expect: false },
   { test: 'HELLO WORLD!',   options: { pattern: 'world', patternFlags: 'i' },   expect: true },
-  { test: 'John Smith',     options: { pattern: '(\\w+)\\s(\\w+)' },            expect: true }
+  { test: 'John Smith',     options: { pattern: '(\\w+)\\s(\\w+)' },            expect: true },
+
+  // With inconsequential option
+  { test: 'John Smith',     options: { pattern: '(\\w+)\\s(\\w+)', someOtherProp: true },  expect: true }
 ];
 
 export const validBooleanUseCases = [
@@ -196,7 +212,10 @@ export const validArrayUseCases = [
   { test: [() => {}],             options: { type: DataType.function } },
   { test: [{a:1}, new Object()],  options: { type: DataType.object } },
   { test: ['1', '2', '4'],        options: { type: DataType.string } },
-  { test: [[1], [2], [4]],        options: { type: DataType.array } }
+  { test: [[1], [2], [4]],        options: { type: DataType.array } },
+
+  // With inconsequential option
+  { test: [[1], [2], [4]],        options: { type: DataType.array, someOtherProp: true } }
 ];
 
 export const arrayWithOptionsUseCases = [
@@ -221,7 +240,10 @@ export const arrayWithOptionsUseCases = [
   { test: [1, 2, 3],          options: { exclMax: 3 },      expect: false },
   { test: [1, 2],             options: { exclMax: 3 },      expect: true },
   { test: [1, 2, 3],          options: { exclMin: 3 },      expect: false },
-  { test: [1, 2, 3, 4],       options: { exclMin: 3 },      expect: true }
+  { test: [1, 2, 3, 4],       options: { exclMin: 3 },      expect: true },
+
+  // With inconsequential option
+  { test: [1, 2, 3, 4],       options: { exclMin: 3, someOtherProp: true },      expect: true }
 ];
 
 export const validFunctionUseCases = [
@@ -237,7 +259,10 @@ export const validObjectUseCases = [
 
 export const optionalObjectUseCases = [
   { test: null, options: { allowNull: true } },
-  { test: [],   options: { arrayAsObject: true } }
+  { test: [],   options: { arrayAsObject: true } },
+
+  // With inconsequential option
+  { test: [],   options: { arrayAsObject: true, someOtherProp: true } },
 ];
 
 export const validUndefinedUseCases = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
   "compilerOptions": {
     "module": "umd",
     "target": "es5",
+    "strictNullChecks": true,
     "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "sourceMap": true,
     "declaration": true,
-    "removeComments": true,
+    "removeComments": false,
     "moduleResolution": "node",
     "outDir": "./dist",
     "types" : [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,15 +16,13 @@ module.exports = function(_env) {
       compress: { warnings: false, screw_ie8: true },
       output: { comments: false },
       sourceMap: true,
-      comments: false,
       mangle: { screw_ie8: true }
     } :
     {
       compress: false,
       output: { comments: false, indent_level: 2 },
       sourceMap: true,
-      comments: false,
-      mangle: { screw_ie8: true, keep_fnames: true },
+      mangle: false,
       beautify: true
     }
   )


### PR DESCRIPTION
* enhance(build): Enforce null checks and no unused items

* enhance(build): protect from some possible `undefined` cases

* feat(is): add `isValidOptions` to detect errors in `isOptions`

     * Validation on the `schema` property is lightweight still, but better than nothing.
     * Currently, when validation fails, `is` throws. Still debating whether it should throw or simply notify of the error and continue.
     * Added unit tests for when a property outside of the schema is present, which should not impact the outcome of `is` or `isValidOptions`.
     * Added unit tests for potential use cases where `isValidOptions` should detect a violation of `isOptions` schema.

* fix(test): tests failing on `typescript ~2.2.0`. Freezing on `typescript ~2.1.0`.