### PR TITLE
fix(isValidOptions): Validate invalid object being passed to `Object.…

### DIFF
--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -151,6 +151,9 @@ export function extendObject(dest: any, ...sources: any[]): any {
  * @returns {boolean}
  */
 export function isValidOptions(_op: isOptions): boolean {
+  /** Ensure object */
+  _op = ( is(_op, DataType.object) ? _op : {} );
+
   /**
    * Test every property.
    * If even a single option is wrong, no pass.

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -335,6 +335,16 @@ describe('`is` and `matchesSchema`', () => {
       expect( () => is(100, DataType.number, { multipleOf: NaN }) ).toThrow();
     });
 
+    it('should not fail when passed unexpected values', () => {
+      expect( () => is(100, DataType.number, {}) ).not.toThrow();
+      expect( () => is(100, DataType.number, null) ).not.toThrow();
+      expect( () => is(100, DataType.number, undefined) ).not.toThrow();
+      expect( () => is(100, DataType.number, NaN) ).not.toThrow();
+      expect( () => is(100, DataType.number, 'hello') ).not.toThrow();
+      expect( () => is(100, DataType.number, Number.NEGATIVE_INFINITY) ).not.toThrow();
+      expect( () => is(100, DataType.number, new Date()) ).not.toThrow();
+    });
+
   });
 
 });


### PR DESCRIPTION
…keys()` (closes #5)

Avoids `TypeError: Cannot convert undefined or null to object` when passing `null` or possibly other unexpected objects as an `options` object