### PR TITLE
feat(release): ensure release status

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prebuild": "npm run clean:dist",
     "build": "node_modules/.bin/tsc",
     "postbuild": "node_modules/.bin/webpack --env.min && node_modules/.bin/webpack",
-    "release": "node_modules/.bin/np && npm logout"
+    "release": "./release-check.sh && node_modules/.bin/np && npm logout"
   },
   "repository": {
     "type": "git",

--- a/release-check.sh
+++ b/release-check.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+test_git_working_dir() {
+  # `git status --porcelain`, unlike `git diff`, will account for untracked files
+  # However, it doesn't provide a meaningful exit code, so we check it's output instead
+  if git_output=$(git status --porcelain) && [ -z "$git_output" ]; then
+    echo -e "\n\r${GREEN}Working directory clean.${NC} Continuing...\n\r"
+  else
+    echo -e "\n\r${RED}The working directory is not clean.${NC}\n\rPlease clear the working directory and try again.\n\r"
+    exit 1
+  fi
+}
+
+test_npm_login() {
+  if npm whoami; then
+    echo -e "\n\r${GREEN}Logged in to \`npm\`.${NC} Continuing...\n\r"
+  else
+    echo -e "\n\r${RED}Not logged in to \`npm\`.${NC}\n\rPlease log in and try again.\n\r"
+    exit 1
+  fi
+}
+
+test_git_working_dir
+test_npm_login


### PR DESCRIPTION
Simple checks before running `np`:

* Checks for a clean working directory
* Checks for the user to be logged into `npm`

Exits with `1` if anything is is wrong to stop execution of further node items

closes #9 