### PR TITLE
Schema edge case validation fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest:watch": "npm run pretest",
     "test:watch": "node_modules/.bin/karma start --no-single-run",
     "test-ci": "npm run build && npm run test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "serve:test": "node_modules/.bin/browser-sync start --directory true -s coverage/",
+    "serve:test": "node_modules/.bin/browser-sync start -s coverage/html",
     "clean:test": "node_modules/.bin/rimraf coverage",
     "clean:dist": "node_modules/.bin/rimraf dist",
     "clean": "npm run clean:test & npm run clean:dist",

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -12,6 +12,7 @@ import {
   isOneOfMultipleTypes,
   extendObject,
   isValidOptions,
+  validDataType,
 } from './is.internal';
 
 /**
@@ -166,6 +167,9 @@ export function is(val: string, type: DataType, options?: isOptionsString): bool
 export function is(val: any[], type: DataType, options?: isOptionsArray): boolean;
 export function is(val: Object, type: DataType, options?: isOptionsObject): boolean;
 export function is(val: any, type: DataType, options?: isOptions): boolean {
+
+  /** Validate `type` */
+  if(!validDataType(type)) { throw 'Provided invalid \`type\` argument' }
 
   /** Validate `options` */
   if(!isValidOptions(options)) {

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -255,7 +255,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If `exclMin` won't exclude Number.NEGATIVE_INFINITY.
    * If `exclMax` won't exclude Number.POSITIVE_INFINITY.
    * `multipleOf` will only be checked when different than 0.
-   * When val is either negative or positive Infinity, `multipleof` will be false.
+   * When val is either negative or positive Infinity, `multipleOf` will be false.
    */
   if( type === DataType.number) {
     return (

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -167,8 +167,8 @@ export function is(val: any[], type: DataType, options?: isOptionsArray): boolea
 export function is(val: Object, type: DataType, options?: isOptionsObject): boolean;
 export function is(val: any, type: DataType, options?: isOptions): boolean {
 
-  /** Check options */
-  if(options !== undefined && !isValidOptions(options as isOptions)) {
+  /** Validate `options` */
+  if(!isValidOptions(options)) {
     throw `Provided invalid options object when testing for ${JSON.stringify(val)}: ${JSON.stringify(options)}`;
   }
 

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -13,6 +13,9 @@ import {
   extendObject,
   isValidOptions,
   validDataType,
+  UNDEF,
+  POS_INF,
+  NEG_INF,
 } from './is.internal';
 
 /**
@@ -34,12 +37,6 @@ export enum DataType {
   any
 };
 
-/** Reference to positive infinity */
-const p_infinity = Number.POSITIVE_INFINITY;
-
-/** Reference to negative infinity */
-const n_infinity = Number.NEGATIVE_INFINITY;
-
 /**
  * Default option set to use within `is`
  */
@@ -51,10 +48,10 @@ const isDefaultOptions: isOptions = {
   schema: null,
   allowNull: false,
   arrayAsObject: false,
-  min: n_infinity,
-  max: p_infinity,
-  exclMin: n_infinity,
-  exclMax: p_infinity,
+  min: NEG_INF,
+  max: POS_INF,
+  exclMin: NEG_INF,
+  exclMax: POS_INF,
   multipleOf: 0
 };
 
@@ -188,7 +185,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     if ( !isMultipleOf(_options.multipleOf as number, 1) ) return false;
 
     let numOptions: isOptions = { multipleOf: ( _options.multipleOf === 0 ? 1 : _options.multipleOf ) };
-    if ( type === DataType.natural ) numOptions.min = ( _options.min !== undefined && _options.min >= 0 ? _options.min : 0 );
+    if ( type === DataType.natural ) numOptions.min = ( _options.min !== UNDEF && _options.min >= 0 ? _options.min : 0 );
 
     return is((val as number), DataType.number, extendObject({}, _options, numOptions) );
   };
@@ -235,10 +232,10 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     return (
       (val as any[]).every( n => isOneOfMultipleTypes(n, _options.type as DataType|DataType[]) ) &&
       ( _options.schema === null || matchesSchema(val, _options.schema as isTypeSchema|isTypeSchema[]) ) &&
-      ( _options.min !== undefined && (val as any[]).length >= _options.min ) &&
-      ( _options.max !== undefined && (val as any[]).length <= _options.max ) &&
-      ( _options.exclMin === n_infinity || ( _options.exclMin !== undefined && (val as any[]).length > _options.exclMin) ) &&
-      ( _options.exclMax === p_infinity || ( _options.exclMax !== undefined && (val as any[]).length < _options.exclMax) )
+      ( _options.min !== UNDEF && (val as any[]).length >= _options.min ) &&
+      ( _options.max !== UNDEF && (val as any[]).length <= _options.max ) &&
+      ( _options.exclMin === NEG_INF || ( _options.exclMin !== UNDEF && (val as any[]).length > _options.exclMin) ) &&
+      ( _options.exclMax === POS_INF || ( _options.exclMax !== UNDEF && (val as any[]).length < _options.exclMax) )
     );
   }
 
@@ -259,10 +256,10 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if( type === DataType.number) {
     return (
-      ( _options.min !== undefined && (val as number) >= _options.min ) &&
-      ( _options.max !== undefined && (val as number) <= _options.max ) &&
-      ( _options.exclMin === n_infinity || ( _options.exclMin !== undefined && (val as number) > _options.exclMin) ) &&
-      ( _options.exclMax === p_infinity || ( _options.exclMax !== undefined && (val as number) < _options.exclMax) ) &&
+      ( _options.min !== UNDEF && (val as number) >= _options.min ) &&
+      ( _options.max !== UNDEF && (val as number) <= _options.max ) &&
+      ( _options.exclMin === NEG_INF || ( _options.exclMin !== UNDEF && (val as number) > _options.exclMin) ) &&
+      ( _options.exclMax === POS_INF || ( _options.exclMax !== UNDEF && (val as number) < _options.exclMax) ) &&
       isMultipleOf(val, _options.multipleOf as number)
     );
   }

--- a/src/is.interfaces.ts
+++ b/src/is.interfaces.ts
@@ -2,7 +2,6 @@ import { DataType } from './is.func';
 
 /**
  * A descriptive model of what an object is expected to be.
- *
  * @export
  * @interface isTypeSchema
  */
@@ -16,7 +15,6 @@ export interface isTypeSchema {
 
 /**
  * The entirety of the options available to use with `is`
- *
  * @export
  * @interface isOptions
  * @extends {isOptionsNumber}
@@ -28,7 +26,6 @@ export interface isOptions extends isOptionsNumber, isOptionsString, isOptionsAr
 
 /**
  * The options available to use on a number type use case with `is`
- *
  * @export
  * @interface isOptionsNumber
  * @extends {isOptionsMinMax}
@@ -39,7 +36,6 @@ export interface isOptionsNumber extends isOptionsMinMax {
 
 /**
  * The options available to use on a string type use case with `is`
- *
  * @export
  * @interface isOptionsString
  */
@@ -51,7 +47,6 @@ export interface isOptionsString {
 
 /**
  * The options available to use on an Array type use case with `is`
- *
  * @export
  * @interface isOptionsArray
  * @extends {isOptionsMinMax}
@@ -63,7 +58,6 @@ export interface isOptionsArray extends isOptionsMinMax, isOptionsSchema {
 
 /**
  * The options available to use on an Object type use case with `is`
- *
  * @export
  * @interface isOptionsObject
  * @extends {isOptionsSchema}
@@ -75,7 +69,6 @@ export interface isOptionsObject extends isOptionsSchema {
 
 /**
  * A shared interface for those option sets that use the `schema` options
- *
  * @export
  * @interface isOptionsSchema
  */
@@ -85,7 +78,6 @@ export interface isOptionsSchema {
 
 /**
  * A shared interface for those option sets that use the `min` and `max` options
- *
  * @export
  * @interface isOptionsMinMax
  */

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -39,7 +39,7 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
 
       const _type: DataType|DataType[] = validDataType(s.type) ? s.type as DataType|DataType[] : DataType.any;
 
-      /** Get the options, if any. Use objecct literal if not available. */
+      /** Get the options, if any. Use object literal if not available. */
       const _typeOptions: isOptions = ( is(s.options as isOptions, DataType.object) ? s.options : {} ) as isOptions;
 
       /** Test if any of the data types matches */
@@ -60,12 +60,12 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
       /** Extract the properties to test for into an array */
       const _propKeys: string[] = ( is(s.props as isOptions, DataType.object) ? Object.keys(s.props) : [] );
 
-      /** Begin tests relevat to properties */
+      /** Begin tests relevant to properties */
       if ( _propKeys.length > 0 ) {
 
         /**
          * Get all keys that are required from the schema,
-         * and then test for required propertes.
+         * and then test for required properties.
          */
         _reqdValid = _propKeys
           .filter( p => s.props && s.props[p] && s.props[p].required === true )

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -86,8 +86,11 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
 
       /** Test items if `array` */
       let _itemsValid = true;
-      if ( _type === DataType.array && _typeValid && s.items !== undefined ) {
-        _itemsValid = (_val as any[]).every( i => matchesSchema(i, s.items as isTypeSchema|isTypeSchema[]) );
+      const inferredArray = ( _type === DataType.any && is(_val, DataType.array) );
+      if ( (_type === DataType.array || inferredArray) && _typeValid && s.items !== undefined ) {
+        _itemsValid = (_val as any[]).every( i => {
+          return matchesSchema(i, s.items as isTypeSchema|isTypeSchema[])
+        });
       }
 
       return _typeValid && _reqdValid && _propsValid && _itemsValid;

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -35,9 +35,11 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
     /** Test every schema until at least one of them matches */
     .some( (s: isTypeSchema) => {
 
-      /** Get type. Use `any` if none is present */
+      /** If type is defined but invalid, schema is false */
+      if(s.type !== undefined && !validDataType(s.type)) return false;
 
-      const _type: DataType|DataType[] = validDataType(s.type) ? s.type as DataType|DataType[] : DataType.any;
+      /** Cache the type. Use `any` if none is present */
+      const _type: DataType|DataType[] = s.type === undefined ? DataType.any : s.type as DataType|DataType[];
 
       /** Get the options, if any. Use object literal if not available. */
       const _typeOptions: isOptions = ( is(s.options as isOptions, DataType.object) ? s.options : {} ) as isOptions;

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -150,33 +150,32 @@ export function extendObject(dest: any, ...sources: any[]): any {
  * @param {isOptions} _op
  * @returns {boolean}
  */
-export function isValidOptions(_op: isOptions): boolean {
+export function isValidOptions(_op: isOptions|undefined): boolean {
   /** Ensure object */
-  _op = ( is(_op, DataType.object) ? _op : {} );
+  const op = ( _op !== undefined && is(_op as isOptions, DataType.object) ? _op : {} ) as isOptions;
 
   /**
    * Test every property.
    * If even a single option is wrong, no pass.
    */
-  return Object.keys(_op)
+  return Object.keys(op)
     .every( o => {
       switch(o) {
         /** DataType cases */
         case 'type':
           /** Ensure we have an array of `DataType` */
-          const types: DataType[] = ( Array.isArray(_op[o]) ? _op[o] : [ _op[o] ] ) as DataType[];
-          return types.length > 0 && types.every( t => (DataType as Object).hasOwnProperty(t.toString()) && typeof t === 'number' );
+          return validDataType(op[o])
 
         /** string cases */
         case 'pattern':
         case 'patternFlags':
-          return typeof _op[o] === 'string';
+          return typeof op[o] === 'string';
 
         /** Boolean cases */
         case 'exclEmpty':
         case 'allowNull':
         case 'arrayAsObject':
-          return typeof _op[o] === 'boolean';
+          return typeof op[o] === 'boolean';
 
         /** Number cases */
         case 'min':
@@ -184,11 +183,11 @@ export function isValidOptions(_op: isOptions): boolean {
         case 'exclMin':
         case 'exclMax':
         case 'multipleOf':
-          return is(_op[o] as number, DataType.number);
+          return is(op[o] as number, DataType.number);
 
         /** Schema case */
         case 'schema':
-          return _op[o] === null || matchesSchema(_op[o], {
+          return op[o] === null || matchesSchema(op[o], {
             /** `isTypeSchema` is always an object */
             type: DataType.object,
             props: {

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -2,6 +2,15 @@ import { is, DataType } from './is.func';
 import { isOptions, isTypeSchema } from './is.interfaces';
 
 /**
+ * CONSTANTS
+ * These tokes are used a lot in this package,
+ * therefore aliasing reduces weight on minification
+ */
+export const UNDEF = undefined;
+export const POS_INF = Number.POSITIVE_INFINITY;
+export const NEG_INF = Number.NEGATIVE_INFINITY;
+
+/**
  * Tests whether a number is multiple of another number.
  * Keep in mind that Infinity, positive or negative, would return
  * NaN when using it with the modulus operator.
@@ -13,8 +22,8 @@ import { isOptions, isTypeSchema } from './is.interfaces';
 export function isMultipleOf(val: number, multipleOf: number): boolean {
   return (
     multipleOf === 0 ||
-    ( val !== Number.NEGATIVE_INFINITY &&
-      val !== Number.POSITIVE_INFINITY &&
+    ( val !== NEG_INF &&
+      val !== POS_INF &&
       // Using Math.abs avoids `-0`
       Math.abs( (val as number) % multipleOf ) === 0
     )
@@ -36,10 +45,10 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
     .some( (s: isTypeSchema) => {
 
       /** If type is defined but invalid, schema is false */
-      if(s.type !== undefined && !validDataType(s.type)) return false;
+      if(s.type !== UNDEF && !validDataType(s.type)) return false;
 
       /** Cache the type. Use `any` if none is present */
-      const _type: DataType|DataType[] = s.type === undefined ? DataType.any : s.type as DataType|DataType[];
+      const _type: DataType|DataType[] = s.type === UNDEF ? DataType.any : s.type as DataType|DataType[];
 
       /** Get the options, if any. Use object literal if not available. */
       const _typeOptions: isOptions = ( is(s.options as isOptions, DataType.object) ? s.options : {} ) as isOptions;
@@ -71,7 +80,7 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
          */
         _reqdValid = _propKeys
           .filter( p => s.props && s.props[p] && s.props[p].required === true )
-          .every( r => _val[r] !== undefined );
+          .every( r => _val[r] !== UNDEF );
 
         /**
          * Iterate over the property keys.
@@ -83,13 +92,13 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
          * However, if it was required, that will have been caught by the check above.
          */
         _propsValid = _propKeys
-          .every( p => ( !!s.props && _val !== undefined && _val[p] !== undefined ? matchesSchema(_val[p], s.props[p]) : true ) );
+          .every( p => ( !!s.props && _val !== UNDEF && _val[p] !== UNDEF ? matchesSchema(_val[p], s.props[p]) : true ) );
       }
 
       /** Test items if `array` */
       let _itemsValid = true;
       const inferredArray = ( _type === DataType.any && is(_val, DataType.array) );
-      if ( (_type === DataType.array || inferredArray) && _typeValid && s.items !== undefined ) {
+      if ( (_type === DataType.array || inferredArray) && _typeValid && s.items !== UNDEF ) {
         _itemsValid = (_val as any[]).every( i => {
           return matchesSchema(i, s.items as isTypeSchema|isTypeSchema[])
         });
@@ -158,7 +167,7 @@ export function extendObject(dest: any, ...sources: any[]): any {
  */
 export function isValidOptions(_op: isOptions|undefined): boolean {
   /** Ensure object */
-  const op = ( _op !== undefined && is(_op as isOptions, DataType.object) ? _op : {} ) as isOptions;
+  const op = ( _op !== UNDEF && is(_op as isOptions, DataType.object) ? _op : {} ) as isOptions;
 
   /**
    * Test every property.
@@ -220,7 +229,7 @@ export function isValidOptions(_op: isOptions|undefined): boolean {
  * @returns {boolean}
  */
 export function validDataType(_val: number|string|(number|string)[]|undefined): boolean {
-  if(_val === undefined) return false;
+  if(_val === UNDEF) return false;
   /** Ensure array */
   const val = Array.isArray(_val) ? _val : [_val];
   /** Check all items are in DataType */

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -36,7 +36,8 @@ export function matchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[]): b
     .some( (s: isTypeSchema) => {
 
       /** Get type. Use `any` if none is present */
-      const _type: DataType|DataType[] = s.type ? s.type : DataType.any;
+
+      const _type: DataType|DataType[] = validDataType(s.type) ? s.type as DataType|DataType[] : DataType.any;
 
       /** Get the options, if any. Use objecct literal if not available. */
       const _typeOptions: isOptions = ( is(s.options as isOptions, DataType.object) ? s.options : {} ) as isOptions;
@@ -206,3 +207,17 @@ export function isValidOptions(_op: isOptions|undefined): boolean {
       return true;
     });
 };
+
+/**
+ * Checks for whether an item is a valid option in the DataType enum
+ * @export
+ * @param {(number|string|(number|string)[]|undefined)} _val
+ * @returns {boolean}
+ */
+export function validDataType(_val: number|string|(number|string)[]|undefined): boolean {
+  if(_val === undefined) return false;
+  /** Ensure array */
+  const val = Array.isArray(_val) ? _val : [_val];
+  /** Check all items are in DataType */
+  return val.every( v => v in DataType && typeof v === 'number' );
+}

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -6,6 +6,8 @@ describe('`is` and `matchesSchema`', () => {
 
   it('should validate for invalid `type` arguments', () => {
     expect( () => is(false, -1) ).toThrow();
+    expect( () => is(false, DataType[1] as any) ).toThrow();
+    expect( () => is(false, 1) ).not.toThrow();
   });
 
   describe('for `number` types', () => {

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -4,10 +4,25 @@ import * as TC from './test-cases/test-cases.spec';
 
 describe('`is` and `matchesSchema`', () => {
 
-  it('should validate for invalid `type` arguments', () => {
-    expect( () => is(false, -1) ).toThrow();
-    expect( () => is(false, DataType[1] as any) ).toThrow();
-    expect( () => is(false, 1) ).not.toThrow();
+  describe('should validate for invalid `type` arguments', () => {
+
+    it('when an out of range number is provided', () => {
+      expect( () => is(false, -1) ).toThrow();
+      expect( matchesSchema(false, { type: -1 }) ).toBe(false);
+      expect( () => is(false, 1) ).not.toThrow();
+      expect( matchesSchema(false, { type: 1 }) ).toBe(false);
+    })
+
+    it('when one of the "named" DataType keys is provided, regardless of technically being a valid DataType key', () => {
+      expect( () => is(false, DataType[1] as any) ).toThrow();
+      expect( matchesSchema(false, { type: DataType[1] as any }) ).toBe(false);
+    })
+
+    it('when undefined is passed', () => {
+      expect( () => is(false, undefined) ).toThrow();
+      /** NOTE: `matchesSchema` here would ignore the `type` because it's optional */
+    })
+
   });
 
   describe('for `number` types', () => {

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -4,6 +4,10 @@ import * as TC from './test-cases/test-cases.spec';
 
 describe('`is` and `matchesSchema`', () => {
 
+  it('should validate for invalid `type` arguments', () => {
+    expect( () => is(false, -1) ).toThrow();
+  });
+
   describe('for `number` types', () => {
     const currentDataType = DataType.number;
 

--- a/src/spec/matchesSchema.spec.ts
+++ b/src/spec/matchesSchema.spec.ts
@@ -121,23 +121,32 @@ describe(`\`matchesSchema\` function`, () => {
     testMatchesSchema( [0,false], { type: DataType.array, items: { type: DataType.boolean } }, false );
   });
 
-  it(`should execute \`matchesSchema\` recursively for \`items\``, () => {
+  it(`should execute \`matchesSchema\` for multiple depths of nested \`items\``, () => {
     testMatchesSchema(
-      ['hello', 'world'],
-      {
-        type: DataType.array,
-        items: { type: DataType.string }
-      },
+      [ ['hello', 'world'] ],
+      { items: { type: DataType.array, items: { type: DataType.string } } },
       true
     );
     testMatchesSchema(
-        ['hello', 100],
-        {
-          type: DataType.array,
-          items: { type: DataType.string }
-        },
-        false
-      );
+      [ ['hello', false] ],
+      { items: { type: DataType.array, items: { type: DataType.string } } },
+      false
+    );
+    testMatchesSchema(
+      [ ['hello', false] ],
+      { items: { type: DataType.array, items: { type: [DataType.string,DataType.boolean] } } },
+      true
+    );
+    testMatchesSchema(
+      [ [ ['hello'], [false] ] ],
+      { items: { type: DataType.array, items: { type: DataType.array, items: { type: DataType.string } } } },
+      false
+    );
+    testMatchesSchema(
+      [ [ ['hello'], [false] ] ],
+      { items: { type: DataType.array, items: { type: DataType.array, items: { type: [DataType.string,DataType.boolean] } } } },
+      true
+    );
   });
 
   it(`should validate for \`required\` properties`, () => {

--- a/src/spec/matchesSchema.spec.ts
+++ b/src/spec/matchesSchema.spec.ts
@@ -48,37 +48,100 @@ describe(`\`matchesSchema\` function`, () => {
           .toBe(true, `Failed for ${n}`) );
   });
 
-  it(`should execute \`matchesSchema\` recursively for \`props\``, () => {
-    expect( matchesSchema(
-      { my: 'qwerty', props: 100 },
+  it(`should not mistake \`props\` from the schema with \`props\` attributes`, () => {
+    const testCases = [
+      { type: DataType.array, value: [] },
+      { type: DataType.boolean, value: false },
+      { type: DataType.boolean, value: true },
+      { type: DataType.function, value: () => {} },
+      { type: DataType.integer, value: -2 },
+      { type: DataType.natural, value: 10 },
+      { type: DataType.number, value: 3.14 },
+      { type: DataType.object, value: {} },
+      { type: DataType.string, value: '0' },
+      { type: DataType.undefined, value: undefined }
+    ];
+    testCases.forEach( tc => {
+      testMatchesSchema(
+        { my: 'qwerty', props: tc.value },
+        {
+          props: {
+            my: { type: DataType.string },
+            props: { type: tc.type }
+          }
+        },
+        true
+      );
+    })
+  });
+
+  it(`should execute \`matchesSchema\` for multiple depths of nested \`props\``, () => {
+    testMatchesSchema(
+      { my: 'qwerty', props: { my: () => {}, props: 100 } },
       {
         props: {
           my: { type: DataType.string },
-          props: { type: DataType.number }
+          props: {
+            type: DataType.object,
+            props: {
+              my: { type: DataType.function },
+              props: { type: DataType.number }
+            }
+          }
         }
-      }
-    ) ).toBe(true);
+      },
+      true
+    );
+  });
+
+  it(`should not mistake \`items\` from the schema with \`items\` attributes`, () => {
+    testMatchesSchema(
+      [ { 'hello': () => {} }, { items: 10 } ],
+      {
+        type: DataType.array,
+        items: {
+          type: DataType.object,
+          props: {
+            items: { type: DataType.number }
+          }
+        }
+      },
+      true
+    );
+  });
+
+  it(`should infer an Array when type is not set to validate \`items\` from the schema with \`items\` attributes`, () => {
+    testMatchesSchema( ['hello','goodbye'], { items: { type: DataType.string } }, true );
+    testMatchesSchema( ['hello','goodbye'], { type: DataType.array, items: { type: DataType.string } }, true );
+    testMatchesSchema( ['hello','goodbye'], { items: { type: DataType.number } }, false );
+    testMatchesSchema( ['hello','goodbye'], { type: DataType.array, items: { type: DataType.number } }, false );
+    testMatchesSchema( [0,false], { items: { type: [DataType.number,DataType.boolean] } }, true );
+    testMatchesSchema( [0,false], { type: DataType.array, items: { type: [DataType.number,DataType.boolean] } }, true );
+    testMatchesSchema( [0,false], { items: { type: DataType.boolean } }, false );
+    testMatchesSchema( [0,false], { type: DataType.array, items: { type: DataType.boolean } }, false );
   });
 
   it(`should execute \`matchesSchema\` recursively for \`items\``, () => {
-    expect( matchesSchema(
+    testMatchesSchema(
       ['hello', 'world'],
       {
         type: DataType.array,
         items: { type: DataType.string }
-      }
-    ) ).toBe(true);
-    expect( matchesSchema(
+      },
+      true
+    );
+    testMatchesSchema(
         ['hello', 100],
         {
           type: DataType.array,
           items: { type: DataType.string }
-        }
-    ) ).toBe(false);
+        },
+        false
+      );
   });
 
   it(`should validate for \`required\` properties`, () => {
-    expect( matchesSchema(
+    testMatchesSchema(
       { my: 'qwerty', props: 100 },
       {
         props: {
@@ -86,9 +149,10 @@ describe(`\`matchesSchema\` function`, () => {
           my: { type: DataType.string },
           props: { type: DataType.number }
         }
-      }
-    ) ).toBe(false);
-    expect( matchesSchema(
+      },
+      false
+    );
+    testMatchesSchema(
       { my: 'qwerty', props: 100, otherprop: {} },
       {
         props: {
@@ -96,9 +160,10 @@ describe(`\`matchesSchema\` function`, () => {
           my: { type: DataType.string },
           props: { type: DataType.number }
         }
-      }
-    ) ).toBe(true);
-    expect( matchesSchema(
+      },
+      true
+    );
+    testMatchesSchema(
       { my: 'qwerty', props: 100, otherprop: {} },
       {
         props: {
@@ -106,9 +171,10 @@ describe(`\`matchesSchema\` function`, () => {
           my: { type: DataType.string },
           props: { type: DataType.number }
         }
-      }
-    ) ).toBe(false);
-    expect( matchesSchema(
+      },
+      false
+    );
+    testMatchesSchema(
       { my: 'qwerty', props: 100, otherprop: {} },
       {
         props: {
@@ -116,9 +182,10 @@ describe(`\`matchesSchema\` function`, () => {
           my: { type: DataType.string },
           props: { type: DataType.number }
         }
-      }
-    ) ).toBe(true);
-    expect( matchesSchema(
+      },
+      true
+    );
+    testMatchesSchema(
       { my: 'qwerty', props: 100, otherprop: {} },
       {
         props: {
@@ -126,8 +193,13 @@ describe(`\`matchesSchema\` function`, () => {
           my: { type: DataType.string },
           props2: { type: DataType.number }
         }
-      }
-    ) ).toBe(true);
+      },
+      true
+    );
   });
 
 });
+
+function testMatchesSchema(_val: any, schema: isTypeSchema|isTypeSchema[], testBool: boolean) {
+  expect( matchesSchema(_val, schema) ).toBe(testBool)
+}


### PR DESCRIPTION
Notably:
* `is` and `matchesSchema` validate for `DataType`.
* `matchesSchema` now infers the type being evaluated as an Array when `_type` is `any` and `items` is present
* Fix for cases where `matchesSchema` was returning false incorrectly because of wrong `DataType` value evaluation