### PR TITLE
perf: refactor to achieve various data access and size improvements

### DIFF
--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -15,7 +15,8 @@ import {
   validDataType,
   UNDEF,
   POS_INF,
-  NEG_INF
+  NEG_INF,
+  DATATYPE
 } from './is.internal'
 
 /**
@@ -40,10 +41,16 @@ export enum DataType {
 }
 
 /**
+ * Merged type to help TS understand these enums have the same values
+ * although one is a regular `enum` and the other is `const enum`
+ */
+type DT = DataType & DATATYPE
+
+/**
  * Default option set to use within `is`
  */
 const isDefaultOptions: isOptions = {
-  type: DataType.any,
+  type: <DT>DATATYPE.any,
   pattern: '[sS]*',
   patternFlags: '',
   exclEmpty: false,
@@ -183,14 +190,14 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * Numeric particular use cases
    * All leverage the `number` check by setting the options their use case requires.
    */
-  if (type === DataType.integer || type === DataType.natural) {
+  if ((<DT>type) == DATATYPE.integer || (<DT>type) == DATATYPE.natural) {
     /** Immediately return false is `multipleOf` is passed, but it's not a multiple of 1. */
     if (!isMultipleOf(_options.multipleOf as number, 1)) return false
 
     let numOptions: isOptions = { multipleOf: _options.multipleOf === 0 ? 1 : _options.multipleOf }
-    if (type === DataType.natural) numOptions.min = _options.min !== UNDEF && _options.min >= 0 ? _options.min : 0
+    if ((<DT>type) == DATATYPE.natural) numOptions.min = _options.min !== UNDEF && _options.min >= 0 ? _options.min : 0
 
-    return is(val as number, DataType.number, extendObject({}, _options, numOptions))
+    return is(val as number, <DT>DATATYPE.number, extendObject({}, _options, numOptions))
   }
 
   /**
@@ -199,7 +206,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If it's allowed, check for `any` or `object`
    */
   if (val === null) {
-    return !_options.allowNull ? false : type == DataType.any || type == DataType.object
+    return !_options.allowNull ? false : (<DT>type) == DATATYPE.any || (<DT>type) == DATATYPE.object
   }
 
   /**
@@ -211,12 +218,12 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If `typeOfCheck` is false, return false.
    */
   const typeOfCheck =
-    type === DataType.any
+    (<DT>type) == DATATYPE.any
       ? true
-      : type === DataType.number
+      : (<DT>type) == DATATYPE.number
         ? typeof val === DataType[type] && !isNaN(val)
-        : type === DataType.array
-          ? typeof val === DataType[DataType.object] && Array.isArray(val)
+        : (<DT>type) == DATATYPE.array
+          ? typeof val === DataType[DATATYPE.object] && Array.isArray(val)
           : typeof val === DataType[type]
   if (!typeOfCheck) return false
 
@@ -224,7 +231,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If `array` is disallowed as object (default), check that the obj is not an array.
    * Is the schema option is set, the object will be validated against the schema.
    */
-  if (type === DataType.object) {
+  if ((<DT>type) == DATATYPE.object) {
     return (
       (!Array.isArray(val) || (_options.arrayAsObject as boolean)) &&
       (_options.schema === null || matchesSchema(val, _options.schema as isTypeSchema | isTypeSchema[]))
@@ -235,7 +242,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If type is `array` and the `type` option is different than `any`,
    * check that all items in the array are of that type.
    */
-  if (type === DataType.array) {
+  if ((<DT>type) == DATATYPE.array) {
     return (
       (val as any[]).every(n => isOneOfMultipleTypes(n, _options.type as DataType | DataType[])) &&
       (_options.schema === null || matchesSchema(val, _options.schema as isTypeSchema | isTypeSchema[])) &&
@@ -247,7 +254,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
   }
 
   /** If type is `string` and empty is disallowed, check for an empty string. */
-  if (type === DataType.string) {
+  if ((<DT>type) == DATATYPE.string) {
     return (
       (!((val as string).length === 0) || !_options.exclEmpty) &&
       new RegExp(_options.pattern as string, _options.patternFlags).test(val)
@@ -261,7 +268,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * `multipleOf` will only be checked when different than 0.
    * When val is either negative or positive Infinity, `multipleOf` will be false.
    */
-  if (type === DataType.number) {
+  if ((<DT>type) == DATATYPE.number) {
     return (
       _options.min !== UNDEF &&
       (val as number) >= _options.min &&

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -222,10 +222,8 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     (<DT>type) == DATATYPE.any
       ? true
       : (<DT>type) == DATATYPE.number
-        ? typeof val === DataType[type] && !isNaN(val)
-        : (<DT>type) == DATATYPE.array
-          ? typeof val === DataType[DATATYPE.object] && Array.isArray(val)
-          : typeof val === DataType[type]
+        ? typeof val == DataType[type] && !isNaN(val)
+        : (<DT>type) == DATATYPE.array ? Array.isArray(val) : typeof val === DataType[type]
   if (!typeOfCheck) return false
 
   /**

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -25,16 +25,18 @@ import {
  * @enum {number}
  */
 export enum DataType {
+  any,
+  // Primitives
+  undefined,
   boolean,
   number,
   integer,
   natural,
   string,
-  function,
+  // Non-primitives
+  function = 11,
   object,
-  array,
-  undefined,
-  any
+  array
 }
 
 /**

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -25,9 +25,9 @@ import {
  * @enum {number}
  */
 export enum DataType {
-  any,
+  any = -1,
   // Primitives
-  undefined,
+  undefined = 1,
   boolean,
   number,
   integer,

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -16,7 +16,8 @@ import {
   UNDEF,
   POS_INF,
   NEG_INF,
-  DATATYPE
+  DATATYPE,
+  testNumberWithinBounds
 } from './is.internal'
 
 /**
@@ -246,10 +247,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     return (
       (val as any[]).every(n => isOneOfMultipleTypes(n, _options.type as DataType | DataType[])) &&
       (_options.schema === null || matchesSchema(val, _options.schema as isTypeSchema | isTypeSchema[])) &&
-      (_options.min !== UNDEF && (val as any[]).length >= _options.min) &&
-      (_options.max !== UNDEF && (val as any[]).length <= _options.max) &&
-      (_options.exclMin === NEG_INF || (_options.exclMin !== UNDEF && (val as any[]).length > _options.exclMin)) &&
-      (_options.exclMax === POS_INF || (_options.exclMax !== UNDEF && (val as any[]).length < _options.exclMax))
+      testNumberWithinBounds((val as any[]).length, _options.min, _options.max, _options.exclMin, _options.exclMax)
     )
   }
 
@@ -270,11 +268,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if ((<DT>type) == DATATYPE.number) {
     return (
-      _options.min !== UNDEF &&
-      (val as number) >= _options.min &&
-      (_options.max !== UNDEF && (val as number) <= _options.max) &&
-      (_options.exclMin === NEG_INF || (_options.exclMin !== UNDEF && (val as number) > _options.exclMin)) &&
-      (_options.exclMax === POS_INF || (_options.exclMax !== UNDEF && (val as number) < _options.exclMax)) &&
+      testNumberWithinBounds(val, _options.min, _options.max, _options.exclMin, _options.exclMax) &&
       isMultipleOf(val, _options.multipleOf as number)
     )
   }

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -193,11 +193,14 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     return is(val as number, DataType.number, extendObject({}, _options, numOptions))
   }
 
-  /** If `allowNull` is true and type is `any` or val is `null`, return true. */
-  if (_options.allowNull && (type === DataType.any || val === null)) return true
-
-  /** If `allowNull` is false and val is `null`, return false. */
-  if (!_options.allowNull && val === null) return false
+  /**
+   * Test for `null`
+   * If it's not allowed, return `false`
+   * If it's allowed, check for `any` or `object`
+   */
+  if (val === null) {
+    return !_options.allowNull ? false : type == DataType.any || type == DataType.object
+  }
 
   /**
    * If `any` type, always true.

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -30,6 +30,18 @@ export function isMultipleOf(val: number, multipleOf: number): boolean {
 }
 
 /**
+ * Tests whether a value is primitive or not
+ *
+ * @export
+ * @param {*} val
+ * @returns {boolean}
+ */
+export function isPrimitive(val: any): boolean {
+  const t = typeof val
+  return val == null || (t != 'function' && t != 'object')
+}
+
+/**
  * Tests an object against an object schema.
  *
  * @export

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -206,54 +206,50 @@ export function isValidOptions(_op: isOptions | undefined): boolean {
    * If even a single option is wrong, no pass.
    */
   return Object.keys(op).every(o => {
-    switch (o) {
-      /** DataType cases */
-      case 'type':
-        /** Ensure we have an array of `DataType` */
-        return validDataType(op[o])
-
-      /** string cases */
-      case 'pattern':
-      case 'patternFlags':
-        return typeof op[o] === 'string'
-
-      /** Boolean cases */
-      case 'exclEmpty':
-      case 'allowNull':
-      case 'arrayAsObject':
-        return typeof op[o] === 'boolean'
-
-      /** Number cases */
-      case 'min':
-      case 'max':
-      case 'exclMin':
-      case 'exclMax':
-      case 'multipleOf':
-        return is(op[o] as number, <DT>DATATYPE.number)
-
-      /** Schema case */
-      case 'schema':
-        return (
-          op[o] === null ||
-          matchesSchema(op[o], {
-            /** `isTypeSchema` is always an object */
-            type: <DT>DATATYPE.object,
-            props: {
-              type: {
-                type: [<DT>DATATYPE.number, <DT>DATATYPE.array],
-                items: { type: <DT>DATATYPE.number }
-              },
-              props: { type: <DT>DATATYPE.object },
-              items: {
-                type: [<DT>DATATYPE.object, <DT>DATATYPE.array],
-                items: { type: <DT>DATATYPE.object }
-              },
-              required: { type: <DT>DATATYPE.boolean },
-              options: { type: <DT>DATATYPE.object }
-            }
-          })
-        )
+    /** DataType case */
+    if (o == 'type') {
+      return validDataType(op[o])
     }
+
+    /** string cases */
+    if (o == 'pattern' || o == 'patternFlags') {
+      return typeof op[o] == 'string'
+    }
+
+    /** Boolean cases */
+    if (o == 'exclEmpty' || o == 'allowNull' || o == 'arrayAsObject') {
+      return typeof op[o] == 'boolean'
+    }
+
+    /** Number cases */
+    if (o == 'min' || o == 'max' || o == 'exclMin' || o == 'exclMax' || o == 'multipleOf') {
+      return typeof op[o] == 'number' && !isNaN(op[o] as number)
+    }
+
+    /** Schema case */
+    if (o == 'schema') {
+      return (
+        op[o] === null ||
+        matchesSchema(op[o], {
+          /** `isTypeSchema` is always an object */
+          type: <DT>DATATYPE.object,
+          props: {
+            type: {
+              type: [<DT>DATATYPE.number, <DT>DATATYPE.array],
+              items: { type: <DT>DATATYPE.number }
+            },
+            props: { type: <DT>DATATYPE.object },
+            items: {
+              type: [<DT>DATATYPE.object, <DT>DATATYPE.array],
+              items: { type: <DT>DATATYPE.object }
+            },
+            required: { type: <DT>DATATYPE.boolean },
+            options: { type: <DT>DATATYPE.object }
+          }
+        })
+      )
+    }
+
     return true
   })
 }

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -51,6 +51,33 @@ export function isMultipleOf(val: number, multipleOf: number): boolean {
 }
 
 /**
+ * Tests a value within bounds of min, max, exclusive min and exclusive max
+ *
+ * @export
+ * @param {number} val
+ * @param {(number | undefined)} min
+ * @param {(number | undefined)} max
+ * @param {(number | undefined)} exclMin
+ * @param {(number | undefined)} exclMax
+ * @returns {boolean}
+ */
+export function testNumberWithinBounds(
+  val: number,
+  min: number | undefined,
+  max: number | undefined,
+  exclMin: number | undefined,
+  exclMax: number | undefined
+): boolean {
+  return (
+    // prettier-ignore
+    (min !== UNDEF && val >= min) &&
+    (max !== UNDEF && val <= max) &&
+    (exclMin === NEG_INF || (exclMin !== UNDEF && val > exclMin)) &&
+    (exclMax === POS_INF || (exclMax !== UNDEF && val < exclMax))
+  )
+}
+
+/**
  * Tests whether a value is primitive or not
  *
  * @export

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -10,6 +10,27 @@ export const UNDEF = undefined
 export const POS_INF = Number.POSITIVE_INFINITY
 export const NEG_INF = Number.NEGATIVE_INFINITY
 
+export const enum DATATYPE {
+  any = -1,
+  // Primitives
+  undefined = 1,
+  boolean,
+  number,
+  integer,
+  natural,
+  string,
+  // Non-primitives
+  function = 11,
+  object,
+  array
+}
+
+/**
+ * Merged type to help TS understand these enums have the same values
+ * although one is a regular `enum` and the other is `const enum`
+ */
+type DT = DataType & DATATYPE
+
 /**
  * Tests whether a number is multiple of another number.
  * Keep in mind that Infinity, positive or negative, would return
@@ -58,10 +79,10 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
         if (s.type !== UNDEF && !validDataType(s.type)) return false
 
         /** Cache the type. Use `any` if none is present */
-        const _type: DataType | DataType[] = s.type === UNDEF ? DataType.any : s.type as DataType | DataType[]
+        const _type: DataType | DataType[] = s.type === UNDEF ? <DT>DATATYPE.any : s.type as DataType | DataType[]
 
         /** Get the options, if any. Use object literal if not available. */
-        const _typeOptions: isOptions = (is(s.options as isOptions, DataType.object) ? s.options : {}) as isOptions
+        const _typeOptions: isOptions = (is(s.options as isOptions, <DT>DATATYPE.object) ? s.options : {}) as isOptions
 
         /** Test if any of the data types matches */
         const _typeValid = isOneOfMultipleTypes(_val, _type, _typeOptions)
@@ -79,7 +100,7 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
         let _reqdValid = true
 
         /** Extract the properties to test for into an array */
-        const _propKeys: string[] = is(s.props as isOptions, DataType.object) ? Object.keys(s.props) : []
+        const _propKeys: string[] = is(s.props as isOptions, <DT>DATATYPE.object) ? Object.keys(s.props as object) : []
 
         /** Begin tests relevant to properties */
         if (_propKeys.length > 0) {
@@ -107,8 +128,8 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
 
         /** Test items if `array` */
         let _itemsValid = true
-        const inferredArray = _type === DataType.any && is(_val, DataType.array)
-        if ((_type === DataType.array || inferredArray) && _typeValid && s.items !== UNDEF) {
+        const inferredArray = _type == (<DT>DATATYPE.any) && is(_val, <DT>DATATYPE.array)
+        if ((_type == (<DT>DATATYPE.array) || inferredArray) && _typeValid && s.items !== UNDEF) {
           _itemsValid = (_val as any[]).every(i => {
             return matchesSchema(i, s.items as isTypeSchema | isTypeSchema[])
           })
@@ -132,10 +153,10 @@ export function isOneOfMultipleTypes(val: any, type: DataType | DataType[], opti
   let types = Array.isArray(type) ? type : [type]
 
   /** Check for presence of `any` */
-  if (types.indexOf(DataType.any) !== -1) return true
+  if (types.indexOf(<DT>DATATYPE.any) != -1) return true
 
   /** Filter out non-`DataType` items */
-  types = types.filter(v => is(v, DataType.number) && (DataType as any).hasOwnProperty(v))
+  types = types.filter(v => is(v, <DT>DATATYPE.number) && (DataType as any).hasOwnProperty(v))
 
   /** Test `val` prop against type validation */
   return types.length > 0 ? types.some(n => is(val, n, options)) : false
@@ -178,7 +199,7 @@ export function extendObject(dest: any, ...sources: any[]): any {
  */
 export function isValidOptions(_op: isOptions | undefined): boolean {
   /** Ensure object */
-  const op = (_op !== UNDEF && is(_op as isOptions, DataType.object) ? _op : {}) as isOptions
+  const op = (_op !== UNDEF && is(_op as isOptions, <DT>DATATYPE.object) ? _op : {}) as isOptions
 
   /**
    * Test every property.
@@ -208,7 +229,7 @@ export function isValidOptions(_op: isOptions | undefined): boolean {
       case 'exclMin':
       case 'exclMax':
       case 'multipleOf':
-        return is(op[o] as number, DataType.number)
+        return is(op[o] as number, <DT>DATATYPE.number)
 
       /** Schema case */
       case 'schema':
@@ -216,19 +237,19 @@ export function isValidOptions(_op: isOptions | undefined): boolean {
           op[o] === null ||
           matchesSchema(op[o], {
             /** `isTypeSchema` is always an object */
-            type: DataType.object,
+            type: <DT>DATATYPE.object,
             props: {
               type: {
-                type: [DataType.number, DataType.array],
-                items: { type: DataType.number }
+                type: [<DT>DATATYPE.number, <DT>DATATYPE.array],
+                items: { type: <DT>DATATYPE.number }
               },
-              props: { type: DataType.object },
+              props: { type: <DT>DATATYPE.object },
               items: {
-                type: [DataType.object, DataType.array],
-                items: { type: DataType.object }
+                type: [<DT>DATATYPE.object, <DT>DATATYPE.array],
+                items: { type: <DT>DATATYPE.object }
               },
-              required: { type: DataType.boolean },
-              options: { type: DataType.object }
+              required: { type: <DT>DATATYPE.boolean },
+              options: { type: <DT>DATATYPE.object }
             }
           })
         )

--- a/src/spec/datatype.spec.ts
+++ b/src/spec/datatype.spec.ts
@@ -1,0 +1,35 @@
+import { DataType } from '../is.func'
+import { DATATYPE } from '../is.internal'
+
+describe('`DataType` parity', () => {
+  it(`should have the same values`, () => {
+    const testedTypes = []
+    const typesToTest = Object.keys(DataType).map(k => parseInt(k, 10)).filter(k => !isNaN(k))
+
+    expect(DataType.any).toBe(DATATYPE.any as number, 'Failed for `any`')
+    testedTypes.push(DataType.any)
+    expect(DataType.undefined).toBe(DATATYPE.undefined as number, 'Failed for `undefined`')
+    testedTypes.push(DataType.undefined)
+    expect(DataType.boolean).toBe(DATATYPE.boolean as number, 'Failed for `boolean`')
+    testedTypes.push(DataType.boolean)
+    expect(DataType.number).toBe(DATATYPE.number as number, 'Failed for `number`')
+    testedTypes.push(DataType.number)
+    expect(DataType.integer).toBe(DATATYPE.integer as number, 'Failed for `integer`')
+    testedTypes.push(DataType.integer)
+    expect(DataType.natural).toBe(DATATYPE.natural as number, 'Failed for `natural`')
+    testedTypes.push(DataType.natural)
+    expect(DataType.string).toBe(DATATYPE.string as number, 'Failed for `string`')
+    testedTypes.push(DataType.string)
+    expect(DataType.function).toBe(DATATYPE.function as number, 'Failed for `function`')
+    testedTypes.push(DataType.function)
+    expect(DataType.object).toBe(DATATYPE.object as number, 'Failed for `object`')
+    testedTypes.push(DataType.object)
+    expect(DataType.array).toBe(DATATYPE.array as number, 'Failed for `array`')
+    testedTypes.push(DataType.array)
+
+    /** This test should validate that all types have been accounted for */
+    expect(typesToTest.every(k => testedTypes.indexOf(k) >= 0)).toBeTruthy(
+      `There's a type that hasn't been accounted for.`
+    )
+  })
+})

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -5,8 +5,10 @@ import * as TC from './test-cases/test-cases.spec'
 describe('`is` and `matchesSchema`', () => {
   describe('should validate for invalid `type` arguments', () => {
     it('when an out of range number is provided', () => {
-      expect(() => is(false, -1)).toThrow()
-      expect(matchesSchema(false, { type: -1 })).toBe(false)
+      expect(() => is(false, -2)).toThrow()
+      expect(matchesSchema(false, { type: -2 })).toBe(false)
+      expect(() => is(false, 0)).toThrow()
+      expect(matchesSchema(false, { type: 0 })).toBe(false)
       expect(() => is(false, 1)).not.toThrow()
       expect(matchesSchema(false, { type: 1 })).toBe(false)
     })

--- a/src/spec/isPrimitive.spec.ts
+++ b/src/spec/isPrimitive.spec.ts
@@ -1,0 +1,35 @@
+import { isPrimitive } from '../is.internal'
+import * as TC from './test-cases/test-cases.spec'
+
+describe('`isPrimitive` function', () => {
+  /**
+   * The below tests are working under the operating assumption that DataType
+   * has been organized to have all primitives to have indexes under 10
+   * and all non-primitives to have indexes over 10.
+   */
+  const cutoff = 10
+
+  it('should return true when primitive value', function() {
+    TC.aggregateUseCases
+      .filter((n, i) => i < cutoff)
+      .forEach(n =>
+        n.forEach(m =>
+          expect(isPrimitive(m)).toBeTruthy(
+            `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for a primitive value`
+          )
+        )
+      )
+  })
+
+  it('should return false when not primitive value', function() {
+    TC.aggregateUseCases
+      .filter((n, i) => i > cutoff)
+      .forEach(n =>
+        n.forEach(m =>
+          expect(isPrimitive(m)).toBeFalsy(
+            `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for a non-primitive value`
+          )
+        )
+      )
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "module": "es2015",
     "target": "es2015",
     "declaration": true,
+    "alwaysStrict": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,


### PR DESCRIPTION
The following improvements were made:
* Sorted `DataType` properties to easily differentiate between primitives and not — will come in handy in the future
* Avoid zero `DataType` index to avoid falsy comparisons
* Reduce redundancies in `null` test
* Create a sister `const enum` for `DataType` for internal use
  This change should improve performance due to removing the overhead of object access in favor of primitive use in comparisons. Additionally, because `DATATYPE` is compiled into just numbers, there will be a size reduction.
  `DATATYPE` will not be exported to JS, only `DataType`.
  A test has been added to ensure that both `DATATYPE` and `DataType` stay in sync.
* Simplify `isValidOptions` to not be switch-based
* Deduplicate number bounds logic into `testNumberWithinBounds`
* Remove unnecessary `typeof` object check for Array

The overall results are a smaller output with a bit more performant checks, especially due to less comparison overhead.