### PR TITLE
test: improve aggregate test cases readability

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean:dist": "node_modules/.bin/rimraf dist",
     "clean": "npm run clean:test & npm run clean:dist",
     "dev": "npm run clean:dist && nodemon --watch 'src' -e 'ts' -x 'node_modules/.bin/tsc'",
-    "format:base": "node_modules/.bin/prettier --print-width 120 --no-semi --single-quote --write",
+    "format:base": "node_modules/.bin/prettier --print-width 120 --no-semi --single-quote --parser typescript --write",
     "format": "npm run format:base -- \"src/**/*.ts\"",
     "prebuild": "npm run clean:dist",
     "build:compile": "node_modules/.bin/tsc",

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -191,12 +191,12 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * Numeric particular use cases
    * All leverage the `number` check by setting the options their use case requires.
    */
-  if ((<DT>type) == DATATYPE.integer || (<DT>type) == DATATYPE.natural) {
+  if (<DT>type == DATATYPE.integer || <DT>type == DATATYPE.natural) {
     /** Immediately return false is `multipleOf` is passed, but it's not a multiple of 1. */
     if (!isMultipleOf(_options.multipleOf as number, 1)) return false
 
     let numOptions: isOptions = { multipleOf: _options.multipleOf === 0 ? 1 : _options.multipleOf }
-    if ((<DT>type) == DATATYPE.natural) numOptions.min = _options.min !== UNDEF && _options.min >= 0 ? _options.min : 0
+    if (<DT>type == DATATYPE.natural) numOptions.min = _options.min !== UNDEF && _options.min >= 0 ? _options.min : 0
 
     return is(val as number, <DT>DATATYPE.number, extendObject({}, _options, numOptions))
   }
@@ -207,7 +207,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If it's allowed, check for `any` or `object`
    */
   if (val === null) {
-    return !_options.allowNull ? false : (<DT>type) == DATATYPE.any || (<DT>type) == DATATYPE.object
+    return !_options.allowNull ? false : <DT>type == DATATYPE.any || <DT>type == DATATYPE.object
   }
 
   /**
@@ -219,18 +219,18 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If `typeOfCheck` is false, return false.
    */
   const typeOfCheck =
-    (<DT>type) == DATATYPE.any
+    <DT>type == DATATYPE.any
       ? true
-      : (<DT>type) == DATATYPE.number
+      : <DT>type == DATATYPE.number
         ? typeof val == DataType[type] && !isNaN(val)
-        : (<DT>type) == DATATYPE.array ? Array.isArray(val) : typeof val === DataType[type]
+        : <DT>type == DATATYPE.array ? Array.isArray(val) : typeof val === DataType[type]
   if (!typeOfCheck) return false
 
   /**
    * If `array` is disallowed as object (default), check that the obj is not an array.
    * Is the schema option is set, the object will be validated against the schema.
    */
-  if ((<DT>type) == DATATYPE.object) {
+  if (<DT>type == DATATYPE.object) {
     return (
       (!Array.isArray(val) || (_options.arrayAsObject as boolean)) &&
       (_options.schema === null || matchesSchema(val, _options.schema as isTypeSchema | isTypeSchema[]))
@@ -241,7 +241,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If type is `array` and the `type` option is different than `any`,
    * check that all items in the array are of that type.
    */
-  if ((<DT>type) == DATATYPE.array) {
+  if (<DT>type == DATATYPE.array) {
     return (
       (val as any[]).every(n => isOneOfMultipleTypes(n, _options.type as DataType | DataType[])) &&
       (_options.schema === null || matchesSchema(val, _options.schema as isTypeSchema | isTypeSchema[])) &&
@@ -250,7 +250,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
   }
 
   /** If type is `string` and empty is disallowed, check for an empty string. */
-  if ((<DT>type) == DATATYPE.string) {
+  if (<DT>type == DATATYPE.string) {
     return (
       (!((val as string).length === 0) || !_options.exclEmpty) &&
       new RegExp(_options.pattern as string, _options.patternFlags).test(val)
@@ -264,7 +264,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * `multipleOf` will only be checked when different than 0.
    * When val is either negative or positive Infinity, `multipleOf` will be false.
    */
-  if ((<DT>type) == DATATYPE.number) {
+  if (<DT>type == DATATYPE.number) {
     return (
       testNumberWithinBounds(val, _options.min, _options.max, _options.exclMin, _options.exclMax) &&
       isMultipleOf(val, _options.multipleOf as number)

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -155,8 +155,8 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
 
         /** Test items if `array` */
         let _itemsValid = true
-        const inferredArray = _type == (<DT>DATATYPE.any) && is(_val, <DT>DATATYPE.array)
-        if ((_type == (<DT>DATATYPE.array) || inferredArray) && _typeValid && s.items !== UNDEF) {
+        const inferredArray = _type == <DT>DATATYPE.any && is(_val, <DT>DATATYPE.array)
+        if ((_type == <DT>DATATYPE.array || inferredArray) && _typeValid && s.items !== UNDEF) {
           _itemsValid = (_val as any[]).every(i => {
             return matchesSchema(i, s.items as isTypeSchema | isTypeSchema[])
           })

--- a/src/spec/datatype.spec.ts
+++ b/src/spec/datatype.spec.ts
@@ -4,7 +4,9 @@ import { DATATYPE } from '../is.internal'
 describe('`DataType` parity', () => {
   it(`should have the same values`, () => {
     const testedTypes = []
-    const typesToTest = Object.keys(DataType).map(k => parseInt(k, 10)).filter(k => !isNaN(k))
+    const typesToTest = Object.keys(DataType)
+      .map(k => parseInt(k, 10))
+      .filter(k => !isNaN(k))
 
     expect(DataType.any).toBe(DATATYPE.any as number, 'Failed for `any`')
     testedTypes.push(DataType.any)

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -1,6 +1,26 @@
 import { is, DataType, isOptions } from '../is.func'
 import { matchesSchema } from '../is.internal'
-import * as TC from './test-cases/test-cases.spec'
+import {
+  validNumberUseCases,
+  validNumberNegativeUseCases,
+  invalidNumberUseCases,
+  numberRangeUseCases,
+  multipleOfUseCases,
+  getDataTypeUseCases,
+  integerUseCases,
+  naturalUseCases,
+  validStringUseCases,
+  stringPatternUseCases,
+  validBooleanUseCases,
+  validArrayUseCases,
+  arrayWithOptionsUseCases,
+  arraySchemaUseCases,
+  validFunctionUseCases,
+  validObjectUseCases,
+  optionalObjectUseCases,
+  objectSchemaUseCases,
+  validUndefinedUseCases
+} from './test-cases/test-cases.spec'
 
 describe('`is` and `matchesSchema`', () => {
   describe('should validate for invalid `type` arguments', () => {
@@ -28,19 +48,19 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.number
 
     it('should work in regular use cases', () => {
-      TC.validNumberUseCases.forEach(n =>
+      validNumberUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           true,
           `Failed for valid \`${DataType[currentDataType]}\` use case ${n}`
         )
       )
-      TC.validNumberNegativeUseCases.forEach(n =>
+      validNumberNegativeUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           true,
           `Failed for valid negative \`${DataType[currentDataType]}\` use case ${n}`
         )
       )
-      TC.invalidNumberUseCases.forEach(n =>
+      invalidNumberUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           false,
           `Failed for invalid \`${DataType[currentDataType]}\` use case ${n}`
@@ -49,7 +69,7 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work in optional use cases', () => {
-      TC.numberRangeUseCases.forEach(n =>
+      numberRangeUseCases.forEach(n =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -59,7 +79,7 @@ describe('`is` and `matchesSchema`', () => {
           )}`
         )
       )
-      TC.multipleOfUseCases.forEach(n =>
+      multipleOfUseCases.forEach(n =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -72,23 +92,19 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work when passed other data types', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              false,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          false,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
     })
 
     describe('particular use cases', () => {
       it('should work for `integer` use cases', () => {
         const currentDataType = DataType.integer
 
-        TC.integerUseCases.forEach(n =>
+        integerUseCases.forEach(n =>
           expect(
             is(n.test, currentDataType, n.options) &&
               matchesSchema(n.test, { type: currentDataType, options: n.options })
@@ -102,7 +118,7 @@ describe('`is` and `matchesSchema`', () => {
       it('should work for `natural` use cases', () => {
         const currentDataType = DataType.natural
 
-        TC.naturalUseCases.forEach(n =>
+        naturalUseCases.forEach(n =>
           expect(
             is(n.test, currentDataType, n.options) &&
               matchesSchema(n.test, { type: currentDataType, options: n.options })
@@ -119,7 +135,7 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.string
 
     it('should work for regular use cases', () => {
-      TC.validStringUseCases.forEach(n =>
+      validStringUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           true,
           `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
@@ -132,7 +148,7 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work in optional use cases', () => {
-      TC.validStringUseCases.forEach(n =>
+      validStringUseCases.forEach(n =>
         expect(
           is(n, currentDataType, { exclEmpty: true }) &&
             matchesSchema(n, { type: currentDataType, options: { exclEmpty: true } })
@@ -142,7 +158,7 @@ describe('`is` and `matchesSchema`', () => {
         is('', currentDataType, { exclEmpty: true }) &&
           matchesSchema('', { type: currentDataType, options: { exclEmpty: true } })
       ).toBe(false, `Failed for valid \`${DataType[currentDataType]}\` test with options on an empty string`)
-      TC.stringPatternUseCases.forEach(n =>
+      stringPatternUseCases.forEach(n =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -155,16 +171,12 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work when passed other data types', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              false,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          false,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
     })
   })
 
@@ -172,7 +184,7 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.boolean
 
     it('should work for regular use cases', () => {
-      TC.validBooleanUseCases.forEach(n =>
+      validBooleanUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           true,
           `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
@@ -181,16 +193,12 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work when passed other data types', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              false,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          false,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
     })
   })
 
@@ -198,7 +206,7 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.array
 
     it('should work for regular use cases', () => {
-      TC.validArrayUseCases.forEach(n =>
+      validArrayUseCases.forEach(n =>
         expect(is(n.test, currentDataType) && matchesSchema(n.test, { type: currentDataType })).toBe(
           true,
           `Failed for valid \`${DataType[currentDataType]}\` test ${n.test}`
@@ -207,7 +215,7 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work in optional use cases', () => {
-      TC.validArrayUseCases.forEach(n =>
+      validArrayUseCases.forEach(n =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -215,7 +223,7 @@ describe('`is` and `matchesSchema`', () => {
           `Failed for valid \`${DataType[currentDataType]}\` test ${n.test} with options ${JSON.stringify(n.options)}`
         )
       )
-      TC.arrayWithOptionsUseCases.forEach(n =>
+      arrayWithOptionsUseCases.forEach(n =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -228,7 +236,7 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work in optional schema use cases', () => {
-      TC.arraySchemaUseCases.forEach((n, i) =>
+      arraySchemaUseCases.forEach((n, i) =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -241,16 +249,12 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work when passed other data types', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              false,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          false,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
     })
   })
 
@@ -258,7 +262,7 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.function
 
     it('should work for regular use cases', () => {
-      TC.validFunctionUseCases.forEach(n =>
+      validFunctionUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           true,
           `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
@@ -267,16 +271,12 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work when passed other data types', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              false,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          false,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
     })
   })
 
@@ -284,19 +284,19 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.object
 
     it('should work for regular use cases', () => {
-      TC.validObjectUseCases.forEach(n =>
+      validObjectUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           true,
           `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
         )
       )
-      TC.optionalObjectUseCases.forEach(n =>
+      optionalObjectUseCases.forEach(n =>
         expect(is(n.test, currentDataType)).toBe(false, `Failed for invalid \`${DataType[currentDataType]}\` test ${n}`)
       )
     })
 
     it('should work in optional use cases', () => {
-      TC.optionalObjectUseCases.forEach(n =>
+      optionalObjectUseCases.forEach(n =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -307,7 +307,7 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work in optional schema use cases', () => {
-      TC.objectSchemaUseCases.forEach(n =>
+      objectSchemaUseCases.forEach(n =>
         expect(
           is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
         ).toBe(
@@ -320,16 +320,12 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work when passed other data types', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              false,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          false,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
     })
   })
 
@@ -337,7 +333,7 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.undefined
 
     it('should work for regular use cases', () => {
-      TC.validUndefinedUseCases.forEach(n =>
+      validUndefinedUseCases.forEach(n =>
         expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
           true,
           `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
@@ -346,16 +342,12 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work when passed other data types', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              false,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          false,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
     })
   })
 
@@ -363,16 +355,12 @@ describe('`is` and `matchesSchema`', () => {
     const currentDataType = DataType.any
 
     it('should work for regular use cases', () => {
-      TC.aggregateUseCases
-        .filter((n, i) => i !== currentDataType)
-        .forEach(n =>
-          n.forEach(m =>
-            expect(is(m, currentDataType) && matchesSchema(m, { type: currentDataType })).toBe(
-              true,
-              `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for \`${DataType[currentDataType]}\``
-            )
-          )
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
+          true,
+          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
         )
+      )
       expect(is(null, currentDataType)).toBe(false, `Failed for valid \`${DataType[currentDataType]}\` test null`)
     })
 

--- a/src/spec/isOneOfMultipleTypes.spec.ts
+++ b/src/spec/isOneOfMultipleTypes.spec.ts
@@ -1,6 +1,6 @@
 import { DataType } from '../is.func'
 import { isOneOfMultipleTypes } from '../is.internal'
-import { aggregateUseCases } from './test-cases/test-cases.spec'
+import { getDataTypeUseCases } from './test-cases/test-cases.spec'
 
 const invalidTypeValues = [
   1000, // The DataType enum is an object with has numbers, but they don't come even close to 1000
@@ -21,12 +21,10 @@ describe(`isOneOfMultipleTypes`, () => {
   })
 
   it(`should immediately return \`true\` when \`any\` is passed`, () => {
-    aggregateUseCases.forEach(n =>
-      n.forEach(m => {
-        expect(isOneOfMultipleTypes(m, DataType.any)).toBe(true, `Failed for \`${m}\` of type \`${typeof m}\``)
-        expect(isOneOfMultipleTypes(m, [DataType.any])).toBe(true, `Failed for \`${m}\` of type \`${typeof m}\``)
-      })
-    )
+    getDataTypeUseCases().forEach(n => {
+      expect(isOneOfMultipleTypes(n, DataType.any)).toBe(true, `Failed for \`${n}\` of type \`${typeof n}\``)
+      expect(isOneOfMultipleTypes(n, [DataType.any])).toBe(true, `Failed for \`${n}\` of type \`${typeof n}\``)
+    })
   })
 
   it(`should test multiple \`DataType\` in addition to a single one`, () => {

--- a/src/spec/isPrimitive.spec.ts
+++ b/src/spec/isPrimitive.spec.ts
@@ -1,5 +1,6 @@
 import { isPrimitive } from '../is.internal'
-import * as TC from './test-cases/test-cases.spec'
+import { getDataTypeUseCases } from './test-cases/test-cases.spec'
+import { DataType } from '../is.func'
 
 describe('`isPrimitive` function', () => {
   /**
@@ -7,29 +8,28 @@ describe('`isPrimitive` function', () => {
    * has been organized to have all primitives to have indexes under 10
    * and all non-primitives to have indexes over 10.
    */
-  const cutoff = 10
+  const PRIMITIVE_CUTOFF = 10
+  const DataTypeKeys = Object.keys(DataType)
+    .map(k => parseInt(k, 10))
+    .filter(k => typeof k == 'number')
+  const nonPrimitiveKeys = DataTypeKeys.filter(i => i > PRIMITIVE_CUTOFF)
+  const primitiveKeys = DataTypeKeys.filter(i => i < PRIMITIVE_CUTOFF)
 
   it('should return true when primitive value', function() {
-    TC.aggregateUseCases
-      .filter((n, i) => i < cutoff)
-      .forEach(n =>
-        n.forEach(m =>
-          expect(isPrimitive(m)).toBeTruthy(
-            `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for a primitive value`
-          )
-        )
+    /** We exclude the non-primitive keys, so only primitives should remain */
+    getDataTypeUseCases(nonPrimitiveKeys).forEach(n =>
+      expect(isPrimitive(n)).toBeTruthy(
+        `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for a primitive value`
       )
+    )
   })
 
   it('should return false when not primitive value', function() {
-    TC.aggregateUseCases
-      .filter((n, i) => i > cutoff)
-      .forEach(n =>
-        n.forEach(m =>
-          expect(isPrimitive(m)).toBeFalsy(
-            `Failed for \`${m}\` of type \`${typeof m}\` passed when validating for a non-primitive value`
-          )
-        )
+    /** We exclude the primitive keys, so only non-primitives should remain */
+    getDataTypeUseCases(primitiveKeys).forEach(n =>
+      expect(isPrimitive(n)).toBeFalsy(
+        `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for a non-primitive value`
       )
+    )
   })
 })

--- a/src/spec/test-cases/test-cases.spec.ts
+++ b/src/spec/test-cases/test-cases.spec.ts
@@ -1,28 +1,48 @@
 import { DataType } from '../../is.func'
-import * as NSTC from './non-schema.spec'
+import {
+  validNumberUseCases,
+  validNumberNegativeUseCases,
+  invalidNumberUseCases,
+  validStringUseCases,
+  validBooleanUseCases,
+  validFunctionUseCases,
+  validArrayUseCases,
+  validObjectUseCases,
+  validUndefinedUseCases
+} from './non-schema.spec'
 
-/**
- * NOTE:
- * This file aggregates several DataType test cases.
- * The use of this is to have a set of all DataType
- * tests to run against every DataType, exclusing
- * the DataType in question, and making sure that
- * it returns `false`.
- */
+const dataTypeTestCaseMap = {
+  [DataType.number]: [...validNumberUseCases, ...validNumberNegativeUseCases, ...invalidNumberUseCases],
+  [DataType.string]: [...validStringUseCases],
+  [DataType.boolean]: [...validBooleanUseCases],
+  [DataType.function]: [...validFunctionUseCases],
+  [DataType.array]: validArrayUseCases.slice().map(n => n.test),
+  [DataType.object]: [...validObjectUseCases],
+  [DataType.undefined]: [...validUndefinedUseCases]
+}
 
-let aggregateUseCases = []
-aggregateUseCases[DataType.number] = [
-  ...NSTC.validNumberUseCases,
-  ...NSTC.validNumberNegativeUseCases,
-  ...NSTC.invalidNumberUseCases
-]
-aggregateUseCases[DataType.string] = [...NSTC.validStringUseCases]
-aggregateUseCases[DataType.boolean] = [...NSTC.validBooleanUseCases]
-aggregateUseCases[DataType.function] = [...NSTC.validFunctionUseCases]
-aggregateUseCases[DataType.array] = NSTC.validArrayUseCases.slice().map(n => n.test)
-aggregateUseCases[DataType.object] = [...NSTC.validObjectUseCases]
-aggregateUseCases[DataType.undefined] = [...NSTC.validUndefinedUseCases]
+export function getDataTypeUseCases(
+  exclusions?: DataType | DataType[],
+  testCaseMap: { [k: number]: any[] } = dataTypeTestCaseMap
+): any[] {
+  /**
+   * Ensure array of strings.
+   * Strings are preferred because Object key iteration will convert keys to strings anyway.
+   * DataType numeric keys will be converted to strings once validated.
+   */
+  let exclude: string[] = (Array.isArray(exclusions) ? exclusions : [exclusions])
+    .filter(k => typeof k == 'number' && k in DataType)
+    .map(k => k.toString())
 
-export { aggregateUseCases }
+  /**
+   * Create array from sample data types.
+   * Filters out exclusions and remaps into an array of arrays of sample data
+   */
+  return Object.keys(testCaseMap)
+    .filter(k => testCaseMap.hasOwnProperty(k) && k in DataType && exclude.indexOf(k) === -1)
+    .map(k => testCaseMap[k])
+    .reduce((a, b) => a.concat(b), [])
+}
+
 export * from './non-schema.spec'
 export * from './schema.spec'


### PR DESCRIPTION
Replaces `aggregateUseCases` with `getDataTypeUseCases(exclusions)`.
This makes the tests that used `aggregateUseCases` clearer because getDataTypeUseCases takes care of necessary exclusions and flattening the test case array.