### PR TITLE
refactor: efficiencies around strict undefined and strict null checks

### DIFF
--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -7,17 +7,17 @@ import {
   isTypeSchema
 } from './is.interfaces'
 import {
-  isMultipleOf,
-  matchesSchema,
-  isOneOfMultipleTypes,
-  extendObject,
-  isValidOptions,
-  validDataType,
-  POS_INF,
-  NEG_INF,
   DATATYPE,
+  extendObject,
+  isDefined,
+  isMultipleOf,
+  isOneOfMultipleTypes,
+  isValidOptions,
+  matchesSchema,
+  NEG_INF,
+  POS_INF,
   testNumberWithinBounds,
-  isDefined
+  validDataType
 } from './is.internal'
 
 /**

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -193,12 +193,12 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if (<DT>type == DATATYPE.integer || <DT>type == DATATYPE.natural) {
     /** Immediately return false is `multipleOf` is passed, but it's not a multiple of 1. */
-    if (!isMultipleOf(_options.multipleOf as number, 1)) return false
+    if (!isMultipleOf(_options.multipleOf!, 1)) return false
 
     let numOptions: isOptions = { multipleOf: _options.multipleOf === 0 ? 1 : _options.multipleOf }
     if (<DT>type == DATATYPE.natural) numOptions.min = isDefined(_options.min) && _options.min! >= 0 ? _options.min : 0
 
-    return is(val as number, <DT>DATATYPE.number, extendObject({}, _options, numOptions))
+    return is(val, <DT>DATATYPE.number, extendObject({}, _options, numOptions))
   }
 
   /**
@@ -232,7 +232,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    */
   if (<DT>type == DATATYPE.object) {
     return (
-      (!Array.isArray(val) || (_options.arrayAsObject as boolean)) &&
+      (!Array.isArray(val) || _options.arrayAsObject!) &&
       (_options.schema === null || matchesSchema(val, _options.schema as isTypeSchema | isTypeSchema[]))
     )
   }
@@ -252,8 +252,8 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
   /** If type is `string` and empty is disallowed, check for an empty string. */
   if (<DT>type == DATATYPE.string) {
     return (
-      (!((val as string).length === 0) || !_options.exclEmpty) &&
-      new RegExp(_options.pattern as string, _options.patternFlags).test(val)
+      ((val as string).length > 0 || !_options.exclEmpty) &&
+      new RegExp(_options.pattern!, _options.patternFlags).test(val)
     )
   }
 
@@ -267,7 +267,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
   if (<DT>type == DATATYPE.number) {
     return (
       testNumberWithinBounds(val, _options.min, _options.max, _options.exclMin, _options.exclMax) &&
-      isMultipleOf(val, _options.multipleOf as number)
+      isMultipleOf(val, _options.multipleOf!)
     )
   }
 

--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -13,11 +13,11 @@ import {
   extendObject,
   isValidOptions,
   validDataType,
-  UNDEF,
   POS_INF,
   NEG_INF,
   DATATYPE,
-  testNumberWithinBounds
+  testNumberWithinBounds,
+  isDefined
 } from './is.internal'
 
 /**
@@ -196,7 +196,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     if (!isMultipleOf(_options.multipleOf as number, 1)) return false
 
     let numOptions: isOptions = { multipleOf: _options.multipleOf === 0 ? 1 : _options.multipleOf }
-    if (<DT>type == DATATYPE.natural) numOptions.min = _options.min !== UNDEF && _options.min >= 0 ? _options.min : 0
+    if (<DT>type == DATATYPE.natural) numOptions.min = isDefined(_options.min) && _options.min! >= 0 ? _options.min : 0
 
     return is(val as number, <DT>DATATYPE.number, extendObject({}, _options, numOptions))
   }

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -55,7 +55,7 @@ export function isMultipleOf(val: number, multipleOf: number): boolean {
     (val !== NEG_INF &&
       val !== POS_INF &&
       // Using Math.abs avoids `-0`
-      Math.abs((val as number) % multipleOf) === 0)
+      Math.abs(val % multipleOf) === 0)
   )
 }
 
@@ -136,7 +136,7 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
         let _reqdValid = true
 
         /** Extract the properties to test for into an array */
-        const _propKeys: string[] = is(s.props as isOptions, <DT>DATATYPE.object) ? Object.keys(s.props as object) : []
+        const _propKeys: string[] = is(s.props as isOptions, <DT>DATATYPE.object) ? Object.keys(s.props!) : []
 
         /** Begin tests relevant to properties */
         if (_propKeys.length > 0) {
@@ -260,7 +260,7 @@ export function isValidOptions(_op: isOptions | undefined): boolean {
 
     /** Number cases */
     if (o == 'min' || o == 'max' || o == 'exclMin' || o == 'exclMax' || o == 'multipleOf') {
-      return typeof op[o] == 'number' && !isNaN(op[o] as number)
+      return typeof op[o] == 'number' && !isNaN(op[o]!)
     }
 
     /** Schema case */

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -117,11 +117,8 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
         /** Cache the type. Use `any` if none is present */
         const _type: DataType | DataType[] = !isDefined(s.type) ? <DT>DATATYPE.any : s.type as DataType | DataType[]
 
-        /** Get the options, if any. Use object literal if not available. */
-        const _typeOptions: isOptions = (isValidOptions(s.options) ? s.options : {}) as isOptions
-
         /** Test if any of the data types matches */
-        const _typeValid = isOneOfMultipleTypes(_val, _type, _typeOptions)
+        const _typeValid = isOneOfMultipleTypes(_val, _type, s.options)
 
         /**
          * Whether the properties match what's reflected in the schema.

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -6,7 +6,6 @@ import { isOptions, isTypeSchema } from './is.interfaces'
  * These tokes are used a lot in this package,
  * therefore aliasing reduces weight on minification
  */
-export const UNDEF = undefined
 export const POS_INF = Number.POSITIVE_INFINITY
 export const NEG_INF = Number.NEGATIVE_INFINITY
 
@@ -30,6 +29,16 @@ export const enum DATATYPE {
  * although one is a regular `enum` and the other is `const enum`
  */
 type DT = DataType & DATATYPE
+
+/**
+ * Strict check for whether a value is defined
+ *
+ * @param {*} v
+ * @returns {boolean}
+ */
+export function isDefined(v: any): boolean {
+  return v !== undefined
+}
 
 /**
  * Tests whether a number is multiple of another number.
@@ -70,10 +79,10 @@ export function testNumberWithinBounds(
 ): boolean {
   return (
     // prettier-ignore
-    (min !== UNDEF && val >= min) &&
-    (max !== UNDEF && val <= max) &&
-    (exclMin === NEG_INF || (exclMin !== UNDEF && val > exclMin)) &&
-    (exclMax === POS_INF || (exclMax !== UNDEF && val < exclMax))
+    (isDefined(min) && val >= min!) &&
+    (isDefined(max) && val <= max!) &&
+    (exclMin === NEG_INF || (isDefined(exclMin) && val > exclMin!)) &&
+    (exclMax === POS_INF || (isDefined(exclMax) && val < exclMax!))
   )
 }
 
@@ -103,13 +112,13 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
       /** Test every schema until at least one of them matches */
       .some((s: isTypeSchema) => {
         /** If type is defined but invalid, schema is false */
-        if (s.type !== UNDEF && !validDataType(s.type)) return false
+        if (isDefined(s.type) && !validDataType(s.type)) return false
 
         /** Cache the type. Use `any` if none is present */
-        const _type: DataType | DataType[] = s.type === UNDEF ? <DT>DATATYPE.any : s.type as DataType | DataType[]
+        const _type: DataType | DataType[] = !isDefined(s.type) ? <DT>DATATYPE.any : s.type as DataType | DataType[]
 
         /** Get the options, if any. Use object literal if not available. */
-        const _typeOptions: isOptions = (is(s.options as isOptions, <DT>DATATYPE.object) ? s.options : {}) as isOptions
+        const _typeOptions: isOptions = (isValidOptions(s.options) ? s.options : {}) as isOptions
 
         /** Test if any of the data types matches */
         const _typeValid = isOneOfMultipleTypes(_val, _type, _typeOptions)
@@ -137,7 +146,7 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
            */
           _reqdValid = _propKeys
             .filter(p => s.props && s.props[p] && s.props[p].required === true)
-            .every(r => _val[r] !== UNDEF)
+            .every(r => isDefined(_val[r]))
 
           /**
            * Iterate over the property keys.
@@ -149,17 +158,20 @@ export function matchesSchema(_val: any, schema: isTypeSchema | isTypeSchema[]):
            * However, if it was required, that will have been caught by the check above.
            */
           _propsValid = _propKeys.every(
-            p => (!!s.props && _val !== UNDEF && _val[p] !== UNDEF ? matchesSchema(_val[p], s.props[p]) : true)
+            p => (!!s.props && isDefined(_val) && isDefined(_val[p]) ? matchesSchema(_val[p], s.props[p]) : true)
           )
         }
 
-        /** Test items if `array` */
+        /**
+         * Whether Array items are valid
+         * Initially assumed as `true`.
+         */
         let _itemsValid = true
-        const inferredArray = _type == <DT>DATATYPE.any && is(_val, <DT>DATATYPE.array)
-        if ((_type == <DT>DATATYPE.array || inferredArray) && _typeValid && s.items !== UNDEF) {
-          _itemsValid = (_val as any[]).every(i => {
-            return matchesSchema(i, s.items as isTypeSchema | isTypeSchema[])
-          })
+        /** If `type` is Any, check whether value is array. If so, check items */
+        const inferredArray = _type == <DT>DATATYPE.any && Array.isArray(_val)
+
+        if ((_type == <DT>DATATYPE.array || inferredArray) && _typeValid && isDefined(s.items)) {
+          _itemsValid = (_val as any[]).every(i => matchesSchema(i, s.items as isTypeSchema | isTypeSchema[]))
         }
 
         return _typeValid && _reqdValid && _propsValid && _itemsValid
@@ -224,7 +236,7 @@ export function extendObject(dest: any, ...sources: any[]): any {
  */
 export function isValidOptions(_op: isOptions | undefined): boolean {
   /** Ensure object */
-  const op = (_op !== UNDEF && is(_op as isOptions, <DT>DATATYPE.object) ? _op : {}) as isOptions
+  const op = (isDefined(_op) && is(_op as isOptions, <DT>DATATYPE.object) ? _op : {}) as isOptions
 
   /**
    * Test every property.

--- a/src/spec/matchesSchema.spec.ts
+++ b/src/spec/matchesSchema.spec.ts
@@ -5,7 +5,7 @@ import { matchesSchema } from '../is.internal'
 describe(`\`matchesSchema\` function`, () => {
   it(`should handle validating undefined`, () => {
     expect(
-      matchesSchema(undefined as Object, { type: DataType.undefined, props: { headline: { type: DataType.string } } })
+      matchesSchema(undefined as object, { type: DataType.undefined, props: { headline: { type: DataType.string } } })
     ).toBe(true)
   })
 


### PR DESCRIPTION
This PR includes a few efficiencies found that result in some minor performance and size improvements.

* Instead of doing strict compares against `undefined` everywhere, that was centralized to a function. There might be a bit of overhead there, but it shouldn't be much.
* Given the above, we have to help Typescript re:strictNullChecks, so I did a review and addressed wherever needed.
* After this refactor, it was surfaced in tests that one validation run for the options object wasn't needed anymore, so I removed it.