### PR TITLE
style: lint tests; remove prettier formatting task

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,9 @@
     "clean:dist": "node_modules/.bin/rimraf dist",
     "clean": "npm run clean:test & npm run clean:dist",
     "dev": "npm run clean:dist && nodemon --watch 'src' -e 'ts' -x 'node_modules/.bin/tsc'",
-    "format:base": "node_modules/.bin/prettier --print-width 120 --no-semi --single-quote --parser typescript --write",
-    "format": "npm run format:base -- \"src/**/*.ts\"",
     "prebuild": "npm run clean:dist",
     "build:compile": "node_modules/.bin/tsc",
-    "build:format": "npm run format:base -- \"dist/*.js\"",
+    "build:format": "node_modules/.bin/prettier --print-width 120 --no-semi --single-quote --write 'dist/*.js'",
     "build:bundle": "node_modules/.bin/webpack --env.min && node_modules/.bin/webpack",
     "build": "npm run build:compile && npm run build:format && npm run build:bundle",
     "release": "./release-check.sh && node_modules/.bin/np && npm logout"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "commitmsg": "validate-commit-msg",
     "lint:tslint": "node_modules/.bin/tslint --type-check --project tsconfig.json --format verbose",
-    "lint:standard": "node_modules/.bin/standard --parser typescript-eslint-parser --plugin typescript --verbose",
+    "lint:standard": "node_modules/.bin/standard --parser typescript-eslint-parser --plugin typescript --verbose src/**/*.ts",
     "lint:watch": "nodemon -w src -w tslint.json -e 'ts,js,json' -x 'npm run lint:tslint -- --force && npm run lint:standard'",
     "lint": "npm run lint:tslint && npm run lint:standard",
     "pretest": "npm run clean:test",

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -77,7 +77,6 @@ export function testNumberWithinBounds(
   exclMax: number | undefined
 ): boolean {
   return (
-    // prettier-ignore
     (min !== undefined && val >= min) &&
     (max !== undefined && val <= max) &&
     (exclMin === NEG_INF || (exclMin !== undefined && val > exclMin)) &&

--- a/src/spec/datatype.spec.ts
+++ b/src/spec/datatype.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-env jasmine */
+
 import { DataType } from '../is.func'
 import { DATATYPE } from '../is.internal'
 import { dataTypeKeys } from './test-cases/test-cases.spec';

--- a/src/spec/datatype.spec.ts
+++ b/src/spec/datatype.spec.ts
@@ -1,12 +1,10 @@
 import { DataType } from '../is.func'
 import { DATATYPE } from '../is.internal'
+import { dataTypeKeys } from './test-cases/test-cases.spec';
 
 describe('`DataType` parity', () => {
   it(`should have the same values`, () => {
     const testedTypes = []
-    const typesToTest = Object.keys(DataType)
-      .map(k => parseInt(k, 10))
-      .filter(k => !isNaN(k))
 
     expect(DataType.any).toBe(DATATYPE.any as number, 'Failed for `any`')
     testedTypes.push(DataType.any)
@@ -30,8 +28,9 @@ describe('`DataType` parity', () => {
     testedTypes.push(DataType.array)
 
     /** This test should validate that all types have been accounted for */
-    expect(typesToTest.every(k => testedTypes.indexOf(k) >= 0)).toBeTruthy(
-      `There's a type that hasn't been accounted for.`
-    )
+    expect(Object.keys(DataType).length / 2)
+      .toBe(dataTypeKeys.length, '`dataTypeKeys` has an incorrect length')
+    expect(dataTypeKeys.every(k => testedTypes.indexOf(k) >= 0))
+      .toBeTruthy(`There's a type that hasn't been accounted for.`)
   })
 })

--- a/src/spec/datatype.spec.ts
+++ b/src/spec/datatype.spec.ts
@@ -2,7 +2,7 @@
 
 import { DataType } from '../is.func'
 import { DATATYPE } from '../is.internal'
-import { dataTypeKeys } from './test-cases/test-cases.spec';
+import { dataTypeKeys } from './test-cases/test-cases.spec'
 
 describe('`DataType` parity', () => {
   it(`should have the same values`, () => {

--- a/src/spec/extendObject.spec.ts
+++ b/src/spec/extendObject.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-env jasmine */
+
 import { extendObject } from '../is.internal'
 
 describe('extendObject', () => {

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -51,246 +51,217 @@ describe('`is` and `matchesSchema`', () => {
 
     it('should work in regular use cases', () => {
       validNumberUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` use case ${n}`
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` use case ${n}`)
       )
       validNumberNegativeUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid negative \`${DataType[currentDataType]}\` use case ${n}`
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid negative \`${DataType[currentDataType]}\` use case ${n}`)
       )
       invalidNumberUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for invalid \`${DataType[currentDataType]}\` use case ${n}`
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(false, `Failed for invalid \`${DataType[currentDataType]}\` use case ${n}`)
       )
     })
 
     it('should work in optional use cases', () => {
-      numberRangeUseCases.forEach(n =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          n.expect,
-          `Failed for \`${DataType[currentDataType]}\` range options use case ${n.test} with options ${JSON.stringify(
-            n.options
-          )}`
-        )
-      )
-      multipleOfUseCases.forEach(n =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          n.expect,
-          `Failed for \`${DataType[
-            currentDataType
-          ]}\` \`multipleOf\` options use case ${n.test} with options ${JSON.stringify(n.options)}`
-        )
-      )
+      numberRangeUseCases.forEach(n => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+        const errType = DataType[currentDataType]
+        const errOptions = JSON.stringify(n.options)
+        const errMessage = `Failed for \`${errType}\` range options use case ${n.test} with options ${errOptions}`
+        expect(test).toBe(n.expect, errMessage)
+      })
+      multipleOfUseCases.forEach(n => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+        const errType = DataType[currentDataType]
+        const errOptions = JSON.stringify(n.options)
+        const errMessage =
+            `Failed for \`${errType}\` \`multipleOf\` options use case ${n.test} with options ${errOptions}`
+        expect(test).toBe(n.expect, errMessage)
+      })
     })
 
     it('should work when passed other data types', () => {
-      getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
-      )
+      getDataTypeUseCases(currentDataType).forEach(n => {
+        const test = is(n, currentDataType) && matchesSchema(n, { type: currentDataType })
+        const errType = DataType[currentDataType]
+        const errMessage = `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``
+        expect(test).toBe(false, errMessage)
+      })
     })
 
     describe('particular use cases', () => {
       it('should work for `integer` use cases', () => {
         const currentDataType = DataType.integer
 
-        integerUseCases.forEach(n =>
-          expect(
-            is(n.test, currentDataType, n.options) &&
+        integerUseCases.forEach(n => {
+          const test = is(n.test, currentDataType, n.options) &&
               matchesSchema(n.test, { type: currentDataType, options: n.options })
-          ).toBe(
-            n.expect,
-            `Failed for \`${DataType[currentDataType]}\` use case ${n.test} with options ${JSON.stringify(n.options)}`
-          )
-        )
+          const errType = DataType[currentDataType]
+          const errOptions = JSON.stringify(n.options)
+          const errMessage = `Failed for \`${errType}\` use case ${n.test} with options ${errOptions}`
+          expect(test).toBe(n.expect, errMessage)
+        })
       })
 
       it('should work for `natural` use cases', () => {
         const currentDataType = DataType.natural
 
-        naturalUseCases.forEach(n =>
-          expect(
-            is(n.test, currentDataType, n.options) &&
+        naturalUseCases.forEach(n => {
+          const test = is(n.test, currentDataType, n.options) &&
               matchesSchema(n.test, { type: currentDataType, options: n.options })
-          ).toBe(
-            n.expect,
-            `Failed for \`${DataType[currentDataType]}\` use case ${n.test} with options ${JSON.stringify(n.options)}`
-          )
-        )
+          const errType = DataType[currentDataType]
+          const errOptions = JSON.stringify(n.options)
+          const errMessage = `Failed for \`${errType}\` use case ${n.test} with options ${errOptions}`
+          expect(test).toBe(n.expect, errMessage)
+        })
       })
     })
   })
 
   describe('for `string` types', () => {
     const currentDataType = DataType.string
+    const errType = DataType[currentDataType]
 
     it('should work for regular use cases', () => {
-      validStringUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
-        )
-      )
-      expect(is('', currentDataType)).toBe(
-        true,
-        `Failed for valid \`${DataType[currentDataType]}\` test on an empty string`
-      )
+      validStringUseCases.forEach(n => {
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test ${n}`)
+      })
+      expect(is('', currentDataType))
+        .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test on an empty string`)
     })
 
     it('should work in optional use cases', () => {
-      validStringUseCases.forEach(n =>
-        expect(
-          is(n, currentDataType, { exclEmpty: true }) &&
+      validStringUseCases.forEach(n => {
+        const test = is(n, currentDataType, { exclEmpty: true }) &&
             matchesSchema(n, { type: currentDataType, options: { exclEmpty: true } })
-        ).toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test with options ${n}`)
-      )
-      expect(
-        is('', currentDataType, { exclEmpty: true }) &&
+        expect(test)
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test with options ${n}`)
+      })
+
+      const emptyStringTest = is('', currentDataType, { exclEmpty: true }) &&
           matchesSchema('', { type: currentDataType, options: { exclEmpty: true } })
-      ).toBe(false, `Failed for valid \`${DataType[currentDataType]}\` test with options on an empty string`)
-      stringPatternUseCases.forEach(n =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          n.expect,
-          `Failed for \`${DataType[currentDataType]}\` pattern use case ${n.test} with options ${JSON.stringify(
-            n.options
-          )}`
-        )
-      )
+      expect(emptyStringTest)
+        .toBe(false, `Failed for valid \`${DataType[currentDataType]}\` test with options on an empty string`)
+
+      stringPatternUseCases.forEach(n => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+
+        const errOptions = JSON.stringify(n.options)
+        const errMessage = `Failed for \`${errType}\` pattern use case ${n.test} with options ${errOptions}`
+        expect(test).toBe(n.expect, errMessage)
+      })
     })
 
     it('should work when passed other data types', () => {
-      getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
-      )
+      getDataTypeUseCases(currentDataType).forEach(n => {
+        const test = is(n, currentDataType) && matchesSchema(n, { type: currentDataType })
+        const errMessage = `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``
+        expect(test).toBe(false, errMessage)
+      })
     })
   })
 
   describe('for `boolean` types', () => {
     const currentDataType = DataType.boolean
+    const errType = DataType[currentDataType]
 
     it('should work for regular use cases', () => {
       validBooleanUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test ${n}`)
       )
     })
 
     it('should work when passed other data types', () => {
-      getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
-      )
+      getDataTypeUseCases(currentDataType).forEach(n => {
+        const errMessage = `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(false, errMessage)
+      })
     })
   })
 
   describe('for `array` types', () => {
     const currentDataType = DataType.array
+    const errType = DataType[currentDataType]
 
     it('should work for regular use cases', () => {
       validArrayUseCases.forEach(n =>
-        expect(is(n.test, currentDataType) && matchesSchema(n.test, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n.test}`
-        )
+        expect(is(n.test, currentDataType) && matchesSchema(n.test, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test ${n.test}`)
       )
     })
 
     it('should work in optional use cases', () => {
-      validArrayUseCases.forEach(n =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n.test} with options ${JSON.stringify(n.options)}`
-        )
-      )
-      arrayWithOptionsUseCases.forEach(n =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          n.expect,
-          `Failed for invalid \`${DataType[currentDataType]}\` test ${n.test} with options ${JSON.stringify(
-            n.options
-          )}. ${n['describe'] ? n['describe'] : ''}`
-        )
-      )
+      validArrayUseCases.forEach(n => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+        const errOptions = JSON.stringify(n.options)
+        const errMessage = `Failed for valid \`${errType}\` test ${n.test} with options ${errOptions}`
+        expect(test).toBe(true, errMessage)
+      })
+      arrayWithOptionsUseCases.forEach(n => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+        const errOptions = JSON.stringify(n.options)
+        const errMessage =
+            `Failed for invalid \`${errType}\` test ${n.test} with options ${errOptions}. ${n['describe'] || ''}`
+        expect(test).toBe(n.expect, errMessage)
+      })
     })
 
     it('should work in optional schema use cases', () => {
-      arraySchemaUseCases.forEach((n, i) =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          n.expect,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${JSON.stringify(
-            n.test
-          )} with options (${i}) ${JSON.stringify(n.options)}: ${n.description}`
-        )
-      )
+      arraySchemaUseCases.forEach((n, i) => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+        const errTest = JSON.stringify(n.test)
+        const errOptions = JSON.stringify(n.options)
+        const errMessage =
+            `Failed for valid \`${errType}\` test ${errTest} with options (${i}) ${errOptions}: ${n.description}`
+        expect(test).toBe(n.expect, errMessage)
+      })
     })
 
     it('should work when passed other data types', () => {
       getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(false, `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``)
       )
     })
   })
 
   describe('for `function` types', () => {
     const currentDataType = DataType.function
+    const errType = DataType[currentDataType]
 
     it('should work for regular use cases', () => {
       validFunctionUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test ${n}`)
       )
     })
 
     it('should work when passed other data types', () => {
-      getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
-      )
+      getDataTypeUseCases(currentDataType).forEach(n => {
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(false, `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``)
+      })
     })
   })
 
   describe('for `object` types', () => {
     const currentDataType = DataType.object
+    const errType = DataType[currentDataType]
 
     it('should work for regular use cases', () => {
       validObjectUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test ${n}`)
       )
       optionalObjectUseCases.forEach(n =>
         expect(is(n.test, currentDataType)).toBe(false, `Failed for invalid \`${DataType[currentDataType]}\` test ${n}`)
@@ -298,79 +269,70 @@ describe('`is` and `matchesSchema`', () => {
     })
 
     it('should work in optional use cases', () => {
-      optionalObjectUseCases.forEach(n =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n.test} with options ${JSON.stringify(n.options)}`
-        )
-      )
+      optionalObjectUseCases.forEach(n => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+        const errOptions = JSON.stringify(n.options)
+        expect(test).toBe(true, `Failed for valid \`${errType}\` test ${n.test} with options ${errOptions}`)
+      })
     })
 
     it('should work in optional schema use cases', () => {
-      objectSchemaUseCases.forEach(n =>
-        expect(
-          is(n.test, currentDataType, n.options) && matchesSchema(n.test, { type: currentDataType, options: n.options })
-        ).toBe(
-          n.expect,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${JSON.stringify(
-            n.test
-          )} with options ${JSON.stringify(n.options)}: ${n.description}`
-        )
-      )
+      objectSchemaUseCases.forEach(n => {
+        const test = is(n.test, currentDataType, n.options) &&
+            matchesSchema(n.test, { type: currentDataType, options: n.options })
+        const errTest = JSON.stringify(n.test)
+        const errOptions = JSON.stringify(n.options)
+        const errMessage =
+            `Failed for valid \`${errType}\` test ${errTest} with options ${errOptions}: ${n.description}`
+        expect(test).toBe(n.expect, errMessage)
+      })
     })
 
     it('should work when passed other data types', () => {
       getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(false, `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``)
       )
     })
   })
 
   describe('for `undefined` types', () => {
     const currentDataType = DataType.undefined
+    const errType = DataType[currentDataType]
 
     it('should work for regular use cases', () => {
       validUndefinedUseCases.forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for valid \`${DataType[currentDataType]}\` test ${n}`
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test ${n}`)
       )
     })
 
     it('should work when passed other data types', () => {
       getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          false,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(false, `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``)
       )
     })
   })
 
   describe('for `any` types', () => {
     const currentDataType = DataType.any
+    const errType = DataType[currentDataType]
 
     it('should work for regular use cases', () => {
       getDataTypeUseCases(currentDataType).forEach(n =>
-        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType })).toBe(
-          true,
-          `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${DataType[currentDataType]}\``
-        )
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``)
       )
-      expect(is(null, currentDataType)).toBe(false, `Failed for valid \`${DataType[currentDataType]}\` test null`)
+      expect(is(null, currentDataType))
+        .toBe(false, `Failed for valid \`${DataType[currentDataType]}\` test null`)
     })
 
     it('should work in optional use cases', () => {
-      expect(
-        is(null, currentDataType, { allowNull: true }) &&
+      const test = is(null, currentDataType, { allowNull: true }) &&
           matchesSchema(null, { type: currentDataType, options: { allowNull: true } })
-      ).toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test null`)
+      expect(test).toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test null`)
     })
   })
 

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -1,4 +1,6 @@
-import { DataType, is, isOptions } from '../is.func'
+/* eslint-env jasmine */
+
+import { DataType, is } from '../is.func'
 import { matchesSchema } from '../is.internal'
 import {
   arraySchemaUseCases,

--- a/src/spec/isOneOfMultipleTypes.spec.ts
+++ b/src/spec/isOneOfMultipleTypes.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-env jasmine */
+
 import { DataType } from '../is.func'
 import { isOneOfMultipleTypes } from '../is.internal'
 import { getDataTypeUseCases } from './test-cases/test-cases.spec'

--- a/src/spec/isOneOfMultipleTypes.spec.ts
+++ b/src/spec/isOneOfMultipleTypes.spec.ts
@@ -10,7 +10,7 @@ const invalidTypeValues = [
   'hello',
   ['hello'],
   {},
-  function() {},
+  function () {},
   null,
   undefined
 ]

--- a/src/spec/isPrimitive.spec.ts
+++ b/src/spec/isPrimitive.spec.ts
@@ -1,5 +1,5 @@
 import { isPrimitive } from '../is.internal'
-import { getDataTypeUseCases } from './test-cases/test-cases.spec'
+import { dataTypeKeys, getDataTypeUseCases } from './test-cases/test-cases.spec'
 import { DataType } from '../is.func'
 
 describe('`isPrimitive` function', () => {
@@ -9,9 +9,6 @@ describe('`isPrimitive` function', () => {
    * and all non-primitives to have indexes over 10.
    */
   const PRIMITIVE_CUTOFF = 10
-  const dataTypeKeys = Object.keys(DataType)
-    .map(k => parseInt(k, 10))
-    .filter(k => typeof k === 'number')
   const nonPrimitiveKeys = dataTypeKeys.filter(i => i > PRIMITIVE_CUTOFF)
   const primitiveKeys = dataTypeKeys.filter(i => i < PRIMITIVE_CUTOFF)
 

--- a/src/spec/isPrimitive.spec.ts
+++ b/src/spec/isPrimitive.spec.ts
@@ -2,7 +2,6 @@
 
 import { isPrimitive } from '../is.internal'
 import { dataTypeKeys, getDataTypeUseCases } from './test-cases/test-cases.spec'
-import { DataType } from '../is.func'
 
 describe('`isPrimitive` function', () => {
   /**
@@ -14,7 +13,7 @@ describe('`isPrimitive` function', () => {
   const nonPrimitiveKeys = dataTypeKeys.filter(i => i > PRIMITIVE_CUTOFF)
   const primitiveKeys = dataTypeKeys.filter(i => i < PRIMITIVE_CUTOFF)
 
-  it('should return true when primitive value', function() {
+  it('should return true when primitive value', () => {
     /** We exclude the non-primitive keys, so only primitives should remain */
     getDataTypeUseCases(nonPrimitiveKeys).forEach(n =>
       expect(isPrimitive(n)).toBeTruthy(
@@ -23,7 +22,7 @@ describe('`isPrimitive` function', () => {
     )
   })
 
-  it('should return false when not primitive value', function() {
+  it('should return false when not primitive value', () => {
     /** We exclude the primitive keys, so only non-primitives should remain */
     getDataTypeUseCases(primitiveKeys).forEach(n =>
       expect(isPrimitive(n)).toBeFalsy(

--- a/src/spec/isPrimitive.spec.ts
+++ b/src/spec/isPrimitive.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-env jasmine */
+
 import { isPrimitive } from '../is.internal'
 import { dataTypeKeys, getDataTypeUseCases } from './test-cases/test-cases.spec'
 import { DataType } from '../is.func'

--- a/src/spec/matchesSchema.spec.ts
+++ b/src/spec/matchesSchema.spec.ts
@@ -1,8 +1,9 @@
+/* eslint-env jasmine */
+// tslint:disable object-literal-sort-keys
+
 import { DataType } from '../is.func'
 import { isTypeSchema } from '../is.interfaces'
 import { matchesSchema } from '../is.internal'
-
-// tslint:disable object-literal-sort-keys
 
 describe(`\`matchesSchema\` function`, () => {
   it(`should handle validating undefined`, () => {

--- a/src/spec/matchesSchema.spec.ts
+++ b/src/spec/matchesSchema.spec.ts
@@ -2,8 +2,9 @@
 // tslint:disable object-literal-sort-keys
 
 import { DataType } from '../is.func'
-import { isTypeSchema } from '../is.interfaces'
 import { matchesSchema } from '../is.internal'
+// eslint-disable-next-line no-unused-vars
+import { isTypeSchema } from '../is.interfaces'
 
 describe(`\`matchesSchema\` function`, () => {
   it(`should handle validating undefined`, () => {
@@ -36,8 +37,8 @@ describe(`\`matchesSchema\` function`, () => {
     )
   })
 
-  it(`should use \`any\  as a \`DataType\` when no \`type\` is present`, () => {
-    const testCases: any[] = [0, 100, -20, 'qwerty', ['qwerty', function() {}], { prop: 'val' }, undefined, null, NaN]
+  it(`should use \`any\`  as a \`DataType\` when no \`type\` is present`, () => {
+    const testCases: any[] = [0, 100, -20, 'qwerty', ['qwerty', function () {}], { prop: 'val' }, undefined, null, NaN]
 
     testCases.forEach(n => expect(matchesSchema(n, {})).toBe(true, `Failed for ${n}`))
   })
@@ -199,6 +200,6 @@ describe(`\`matchesSchema\` function`, () => {
   })
 })
 
-function testMatchesSchema(val: any, schema: isTypeSchema | isTypeSchema[], testBool: boolean) {
+function testMatchesSchema (val: any, schema: isTypeSchema | isTypeSchema[], testBool: boolean) {
   expect(matchesSchema(val, schema)).toBe(testBool)
 }

--- a/src/spec/test-cases/non-schema.spec.ts
+++ b/src/spec/test-cases/non-schema.spec.ts
@@ -1,6 +1,7 @@
-import { DataType, isOptions } from '../../is.func'
-
+/* eslint-env jasmine */
 // tslint:disable object-literal-sort-keys
+
+import { DataType, isOptions } from '../../is.func'
 
 export const validNumberUseCases = [37, 3.14, Math.LN2, Infinity, Number.POSITIVE_INFINITY, Number(1)]
 

--- a/src/spec/test-cases/non-schema.spec.ts
+++ b/src/spec/test-cases/non-schema.spec.ts
@@ -9,7 +9,6 @@ export const validNumberNegativeUseCases = [Number.NEGATIVE_INFINITY, -37, -3.14
 
 export const invalidNumberUseCases = [NaN, Number.NaN]
 
-// prettier-ignore
 export const numberRangeUseCases = [
   // `max` and `exclMax` tests against 0
   { test: 0,      options: { max: 0 },                expect: true },
@@ -91,7 +90,6 @@ export const numberRangeUseCases = [
   { test: -3.13,  options: { min: -3.13, exclMin: -3.13, someOtherProp: true },  expect: false },
 ];
 
-// prettier-ignore
 export const multipleOfUseCases = [
   { test: Number.POSITIVE_INFINITY,
                     options: { multipleOf: 1 },     expect: false },
@@ -116,7 +114,6 @@ export const multipleOfUseCases = [
   { test: 6.28,     options: { multipleOf: -3.14, someOtherProp: true }, expect: true }
 ];
 
-// prettier-ignore
 export const integerUseCases = [
   { test: 21,             options: {},  expect: true },
   { test: 4,              options: {},  expect: true },
@@ -139,7 +136,6 @@ export const integerUseCases = [
   { test: 3.14,           options: { multipleOf: 3.14, someOtherProp: true },  expect: false }
 ];
 
-// prettier-ignore
 export const naturalUseCases = [
   { test: 21,             options: {},  expect: true },
   { test: 4,              options: {},  expect: true },
@@ -176,7 +172,6 @@ export const validStringUseCases = [
   String('abc')
 ]
 
-// prettier-ignore
 export const stringPatternUseCases = [
   { test: 'cdbbdbsbz',      options: { pattern: 'd(b+)d', patternFlags: 'g' },  expect: true },
   { test: 'hi there!',      options: { pattern: '!' },                          expect: true },
@@ -194,7 +189,6 @@ export const stringPatternUseCases = [
 
 export const validBooleanUseCases = [true, false, Boolean(true)]
 
-// prettier-ignore
 export const validArrayUseCases = [
   { test: [1, 2, 4],              options: { type: DataType.number } },
   { test: [true, false],          options: { type: DataType.boolean } },
@@ -207,7 +201,6 @@ export const validArrayUseCases = [
   { test: [[1], [2], [4]],        options: { type: DataType.array, someOtherProp: true } }
 ];
 
-// prettier-ignore
 export const arrayWithOptionsUseCases = [
   { test: [1, '2', 4],        options: { type: DataType.number },     expect: false },
   { test: [true, 'false'],    options: { type: DataType.boolean },    expect: false },

--- a/src/spec/test-cases/schema.spec.ts
+++ b/src/spec/test-cases/schema.spec.ts
@@ -1,6 +1,7 @@
-import { DataType, isOptions } from '../../is.func'
-
+/* eslint-env jasmine */
 // tslint:disable no-object-literal-type-assertion object-literal-sort-keys
+
+import { DataType, isOptions } from '../../is.func'
 
 export const arraySchemaUseCases = [
   {

--- a/src/spec/test-cases/test-cases.spec.ts
+++ b/src/spec/test-cases/test-cases.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-env jasmine */
+
 import { DataType } from '../../is.func'
 import {
   invalidNumberUseCases,

--- a/src/spec/test-cases/test-cases.spec.ts
+++ b/src/spec/test-cases/test-cases.spec.ts
@@ -44,5 +44,12 @@ export function getDataTypeUseCases(
     .reduce((a, b) => a.concat(b), [])
 }
 
+/**
+ * An array with all the non-named DataType keys.
+ */
+export const dataTypeKeys: number[] = Object.keys(DataType)
+  .map(k => parseInt(k, 10))
+  .filter(k => typeof k === 'number' && !isNaN(k))
+
 export * from './non-schema.spec'
 export * from './schema.spec'


### PR DESCRIPTION
Prettier is not working out. There are certain cases where it very much breaks down. Most importantly, it formats tests poorly, so instead, I’ve added linting rules in previous commits as well as linting through `standard`.