### PR TITLE
refactor: allow `any` regardless of value

### DIFF
--- a/src/is.func.ts
+++ b/src/is.func.ts
@@ -168,6 +168,9 @@ export function is(val: string, type: DataType, options?: isOptionsString): bool
 export function is(val: any[], type: DataType, options?: isOptionsArray): boolean
 export function is(val: Object, type: DataType, options?: isOptionsObject): boolean
 export function is(val: any, type: DataType, options?: isOptions): boolean {
+
+  if (<DT>type === DATATYPE.any) return true;
+
   /** Validate `type` */
   if (!validDataType(type)) {
     throw Error('Provided invalid `type` argument')
@@ -204,7 +207,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If it's allowed, check for `any` or `object`
    */
   if (val === null) {
-    return !opts.allowNull ? false : <DT>type === DATATYPE.any || <DT>type === DATATYPE.object
+    return !opts.allowNull ? false : <DT>type === DATATYPE.object
   }
 
   /**
@@ -216,9 +219,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
    * If `typeOfCheck` is false, return false.
    */
   const typeOfCheck =
-    <DT>type === DATATYPE.any
-      ? true
-      : <DT>type === DATATYPE.number
+    <DT>type === DATATYPE.number
         ? typeof val === DataType[type] && !isNaN(val)
         : <DT>type === DATATYPE.array ? Array.isArray(val) : typeof val === DataType[type]
   if (!typeOfCheck) return false

--- a/src/is.internal.ts
+++ b/src/is.internal.ts
@@ -84,77 +84,76 @@ export function isPrimitive(val: any): boolean {
  * Tests an object against an object schema.
  */
 export function matchesSchema(val: any, schema: isTypeSchema | isTypeSchema[]): boolean {
-  return (
-    (Array.isArray(schema) ? schema : [schema])
-      /** Test every schema until at least one of them matches */
-      .some((s: isTypeSchema) => {
-        /** If type is defined but invalid, schema is false */
-        if (s.type !== undefined && !validDataType(s.type)) return false
+  const schemas = Array.isArray(schema) ? schema : [schema];
 
-        /** Cache the type. Use `any` if none is present */
-        const sType: DataType | DataType[] = s.type === undefined ? <DT>DATATYPE.any : s.type
+  /** Test every schema until at least one of them matches */
+  return schemas.some((s: isTypeSchema) => {
+    /** If type is defined but invalid, schema is false */
+    if (s.type !== undefined && !validDataType(s.type)) return false
 
-        /** Test if any of the data types matches */
-        const sTypeValid = isOneOfMultipleTypes(val, sType, s.options)
+    /** Cache the type. Use `any` if none is present */
+    const sType: DataType | DataType[] = s.type === undefined ? <DT>DATATYPE.any : s.type
 
-        /**
-         * Whether the properties match what's reflected in the schema.
-         * Initially assumed as `true`.
-         */
-        let sPropsValid = true
+    /** Test if any of the data types matches */
+    const sTypeValid = isOneOfMultipleTypes(val, sType, s.options)
 
-        /**
-         * Whether the required properties are present.
-         * Initially assumed as `true`.
-         */
-        let sRequiredValid = true
+    /**
+     * Whether the properties match what's reflected in the schema.
+     * Initially assumed as `true`.
+     */
+    let sPropsValid = true
 
-        /** Extract the properties to test for into an array */
-        const sProps = s.props && typeof s.props === 'object' ? s.props : {};
-        const sPropKeys: string[] = Object.keys(sProps)
+    /**
+     * Whether the required properties are present.
+     * Initially assumed as `true`.
+     */
+    let sRequiredValid = true
 
-        /** Begin tests relevant to properties */
-        if (sPropKeys.length > 0) {
-          /**
-           * Get all keys that are required from the schema,
-           * and then test for required properties.
-           */
-          sRequiredValid = sPropKeys
-            .filter(p => sProps[p].required === true)
-            .every(r => val[r] !== undefined)
+    /** Extract the properties to test for into an array */
+    const sProps = s.props && typeof s.props === 'object' ? s.props : {};
+    const sPropKeys: string[] = Object.keys(sProps)
 
-          /**
-           * Iterate over the property keys.
-           *
-           * If the subject has the property we're seeking,
-           * `matchesSchema` is called on that property.
-           *
-           * If `p`, the property, is not an object, it won't be validated against.
-           * However, if it was required, that will have been caught by the check above.
-           */
-          sPropsValid = sPropKeys.every(p =>
-            !!s.props && val !== undefined && val[p] !== undefined
-              ? matchesSchema(val[p], s.props[p])
-              : true
-          )
-        }
+    /** Begin tests relevant to properties */
+    if (sPropKeys.length > 0) {
+      /**
+       * Get all keys that are required from the schema,
+       * and then test for required properties.
+       */
+      sRequiredValid = sPropKeys
+        .filter(p => sProps[p].required === true)
+        .every(r => val[r] !== undefined)
 
-        /** If `type` is Any, check whether value is array. If so, check items */
-        const inferredArray = sType === <DT>DATATYPE.any && Array.isArray(val)
+      /**
+       * Iterate over the property keys.
+       *
+       * If the subject has the property we're seeking,
+       * `matchesSchema` is called on that property.
+       *
+       * If `p`, the property, is not an object, it won't be validated against.
+       * However, if it was required, that will have been caught by the check above.
+       */
+      sPropsValid = sPropKeys.every(p =>
+        !!s.props && val !== undefined && val[p] !== undefined
+          ? matchesSchema(val[p], s.props[p])
+          : true
+      )
+    }
 
-        /**
-         * Whether Array items are valid
-         * If we're dealing with an array, even if inferred, check the `items`. Otherwise, true.
-         */
-        const sItemsValid = (
-          (sType === <DT>DATATYPE.array || inferredArray) && sTypeValid && s.items !== undefined
-            ? (val as any[]).every(i => matchesSchema(i, s.items as isTypeSchema | isTypeSchema[]))
-            : true
-        );
+    /** If `type` is Any, check whether value is array. If so, check items */
+    const inferredArray = sType === <DT>DATATYPE.any && Array.isArray(val)
 
-        return sTypeValid && sRequiredValid && sPropsValid && sItemsValid
-      })
-  )
+    /**
+     * Whether Array items are valid
+     * If we're dealing with an array, even if inferred, check the `items`. Otherwise, true.
+     */
+    const sItemsValid = (
+      (sType === <DT>DATATYPE.array || inferredArray) && sTypeValid && s.items !== undefined
+        ? (val as any[]).every(i => matchesSchema(i, s.items as isTypeSchema | isTypeSchema[]))
+        : true
+    );
+
+    return sTypeValid && sRequiredValid && sPropsValid && sItemsValid
+  })
 }
 
 /**
@@ -169,9 +168,7 @@ export function isOneOfMultipleTypes(val: any, type: DataType | DataType[], opti
    * Else if `types` contain any, return true
    * Else test against `is`
    */
-  return types.length > 0
-    ? types.indexOf(<DT>DATATYPE.any) >= 0 || types.some(n => is(val, n, options))
-    : false
+  return types.length > 0 ? types.some(n => is(val, n, options)) : false
 }
 
 /**

--- a/src/spec/is.spec.ts
+++ b/src/spec/is.spec.ts
@@ -28,11 +28,11 @@ describe('`is` and `matchesSchema`', () => {
   describe('should validate for invalid `type` arguments', () => {
     it('when an out of range number is provided', () => {
       expect(() => is(false, -2)).toThrow()
-      expect(matchesSchema(false, { type: -2 })).toBe(false)
+      expect(matchesSchema(false, { type: -2 })).toBe(false, 'Failed for -2')
       expect(() => is(false, 0)).toThrow()
-      expect(matchesSchema(false, { type: 0 })).toBe(false)
+      expect(matchesSchema(false, { type: 0 })).toBe(false, 'Failed for 0')
       expect(() => is(false, 1)).not.toThrow()
-      expect(matchesSchema(false, { type: 1 })).toBe(false)
+      expect(matchesSchema(false, { type: 1 })).toBe(false, 'Failed for 1')
     })
 
     it('when a "named" DataType key is provided, regardless of technically being a valid DataType key', () => {
@@ -326,7 +326,7 @@ describe('`is` and `matchesSchema`', () => {
           .toBe(true, `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``)
       )
       expect(is(null, currentDataType))
-        .toBe(false, `Failed for valid \`${DataType[currentDataType]}\` test null`)
+        .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test null`)
     })
 
     it('should work in optional use cases', () => {


### PR DESCRIPTION
BREAKING CHANGE: before `null` would not be considered valid under `any`, but after sleeping on this for a while I believe `any` should literally just be the catch all for ‘any’ type.

Additionally, this brings a huge perf boost for when `any` is the type being passed.