### PR TITLE
feat: add null as datatype and remove as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The data types available to test for are:
 * `object`
 * `array`
 * `undefined`
+* `null`
 * `any`: catch all
 
 This function is opinionated in the sense that:
 
-* When testing for `object` and `any`, `null` will be disallowed by default. If desired, an optional `allowNull` can be passed to allow that use case.
 * When testing for an `object`, Arrays will be disallowed by default. If desired, an optional `arrayAsObject` can be passed to allow that use case. Note that there is a separate check for `array`.
 * When testing for `number`, `integer`, or `natural`, `NaN` will be disallowed at all times.
 
@@ -101,7 +101,6 @@ The default values for options are:
 type: DataType.any // Used for `array` use cases
 exclEmpty: false // Used for `string` use cases
 schema: null // Used for `object` and `any` use cases
-allowNull: false // Used for `object` and `any` use cases
 arrayAsObject: false // Used for `object` use cases
 min: Number.NEGATIVE_INFINITY // Used for `number` use cases
 max: Number.POSITIVE_INFINITY // Used for `number` use cases

--- a/spec/datatype.spec.ts
+++ b/spec/datatype.spec.ts
@@ -9,6 +9,8 @@ describe('`DataType` parity', () => {
     testedTypes.push(DataType.any)
     expect(DataType.undefined).toBe(DATATYPE.undefined as number, 'Failed for `undefined`')
     testedTypes.push(DataType.undefined)
+    expect(DataType.null).toBe(DATATYPE.null as number, 'Failed for `null`')
+    testedTypes.push(DataType.null)
     expect(DataType.boolean).toBe(DATATYPE.boolean as number, 'Failed for `boolean`')
     testedTypes.push(DataType.boolean)
     expect(DataType.number).toBe(DATATYPE.number as number, 'Failed for `number`')

--- a/spec/is.spec.ts
+++ b/spec/is.spec.ts
@@ -16,6 +16,7 @@ import {
   validArrayUseCases,
   validBooleanUseCases,
   validFunctionUseCases,
+  validNullUseCases,
   validNumberNegativeUseCases,
   validNumberUseCases,
   validObjectUseCases,
@@ -315,6 +316,25 @@ describe('`is` and `matchesSchema`', () => {
     })
   })
 
+  describe('for `null` types', () => {
+    const currentDataType = DataType.null
+    const errType = DataType[currentDataType]
+
+    it('should work for regular use cases', () => {
+      validNullUseCases.forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test ${n}`)
+      )
+    })
+
+    it('should work when passed other data types', () => {
+      getDataTypeUseCases(currentDataType).forEach(n =>
+        expect(is(n, currentDataType) && matchesSchema(n, { type: currentDataType }))
+          .toBe(false, `Failed for \`${n}\` of type \`${typeof n}\` passed when validating for \`${errType}\``)
+      )
+    })
+  })
+
   describe('for `any` types', () => {
     const currentDataType = DataType.any
     const errType = DataType[currentDataType]
@@ -326,12 +346,6 @@ describe('`is` and `matchesSchema`', () => {
       )
       expect(is(null, currentDataType))
         .toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test null`)
-    })
-
-    it('should work in optional use cases', () => {
-      const test = is(null, currentDataType, { allowNull: true }) &&
-          matchesSchema(null, { type: currentDataType, options: { allowNull: true } })
-      expect(test).toBe(true, `Failed for valid \`${DataType[currentDataType]}\` test null`)
     })
   })
 
@@ -367,13 +381,6 @@ describe('`is` and `matchesSchema`', () => {
       expect(() => is({}, DataType.object, { schema: null })).not.toThrow()
       expect(() => is({}, DataType.object, { schema: {} })).not.toThrow()
       expect(() => is({}, DataType.object, { schema: 'true' } as any)).toThrow()
-    })
-
-    it('should detect invalid values assigned to `allowNull`', () => {
-      expect(() => is(null, DataType.object, { allowNull: undefined })).not.toThrow()
-      expect(() => is(null, DataType.object, { allowNull: true })).not.toThrow()
-      expect(() => is(null, DataType.object, { allowNull: 'true' } as any)).toThrow()
-      expect(() => is(null, DataType.object, { allowNull: 1 } as any)).toThrow()
     })
 
     it('should detect invalid values assigned to `arrayAsObject`', () => {

--- a/spec/test-cases/non-schema.spec.ts
+++ b/spec/test-cases/non-schema.spec.ts
@@ -231,11 +231,12 @@ export const validFunctionUseCases = [function () {}, class C {}, Math.sin]
 export const validObjectUseCases = [{ a: 1 }, {}]
 
 export const optionalObjectUseCases = [
-  { test: null, options: { allowNull: true } },
   { test: [], options: { arrayAsObject: true } },
 
   // With inconsequential option
   { test: [], options: { arrayAsObject: true, someOtherProp: true } }
 ]
+
+export const validNullUseCases = [null]
 
 export const validUndefinedUseCases = [undefined]

--- a/spec/test-cases/test-cases.spec.ts
+++ b/spec/test-cases/test-cases.spec.ts
@@ -4,6 +4,7 @@ import {
   validArrayUseCases,
   validBooleanUseCases,
   validFunctionUseCases,
+  validNullUseCases,
   validNumberNegativeUseCases,
   validNumberUseCases,
   validObjectUseCases,
@@ -18,7 +19,8 @@ const dataTypeTestCaseMap = {
   [DataType.function]: [...validFunctionUseCases],
   [DataType.array]: validArrayUseCases.slice().map(n => n.test),
   [DataType.object]: [...validObjectUseCases],
-  [DataType.undefined]: [...validUndefinedUseCases]
+  [DataType.undefined]: [...validUndefinedUseCases],
+  [DataType.null]: [...validNullUseCases]
 }
 
 export function getDataTypeUseCases (

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -5,6 +5,7 @@ export enum DataType {
   any = -1,
   // Primitives
   undefined = 1,
+  null,
   boolean,
   number,
   integer,
@@ -24,6 +25,7 @@ export const enum DATATYPE {
   any = -1,
   // Primitives
   undefined = 1,
+  null,
   boolean,
   number,
   integer,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,7 +51,6 @@ export interface StrictOptionsArray extends StrictOptionsMinMax, StrictOptionsSc
  */
 export type isOptionsObject = Partial<StrictOptionsObject>
 export interface StrictOptionsObject extends StrictOptionsSchema {
-  allowNull: boolean
   arrayAsObject: boolean
 }
 

--- a/src/is.ts
+++ b/src/is.ts
@@ -33,9 +33,6 @@ import { Options } from './options'
  *
  * This function is opinionated in the sense that:
  *
- * * When testing for `object` and `any`, `null` will be disallowed
- *   by default. If desired, an optional `allowNull` can be passed
- *   to allow that use case.
  * * When testing for an `object`, Arrays will be disallowed by default.
  *   If desired, an optional `arrayAsObject` can be passed to allow that
  *   use case. Note that there is a separate check for `array`.
@@ -50,7 +47,6 @@ import { Options } from './options'
  * type: DataType.any // Used for `array` use cases
  * exclEmpty: false // Used for `string` use cases
  * schema: null // Used for `object` and `any` use cases
- * allowNull: false // Used for `object` and `any` use cases
  * arrayAsObject: false // Used for `object` use cases
  * min: Number.NEGATIVE_INFINITY // Used for `number` use cases
  * max: Number.POSITIVE_INFINITY // Used for `number` use cases
@@ -112,14 +108,25 @@ import { Options } from './options'
  * @param type - One of the DataType enum values
  * @returns Whether the validation is true or not
  */
-export function is (val: undefined | boolean, type: DataType): boolean
+export function is (val: undefined | null | boolean, type: DataType): boolean
 export function is (val: number, type: DataType, options?: isOptionsNumber): boolean
 export function is (val: string, type: DataType, options?: isOptionsString): boolean
 export function is (val: any[], type: DataType, options?: isOptionsArray): boolean
-export function is (val: Object, type: DataType, options?: isOptionsObject): boolean
+export function is (val: object, type: DataType, options?: isOptionsObject): boolean
 export function is (val: any, type: DataType, options?: isOptions): boolean {
 
+  /** Any */
   if (<DT> type === DATATYPE.any) return true
+
+  /** Undefined */
+  if (<DT> type === DATATYPE.undefined || val === undefined) {
+    return <DT> type === DATATYPE.undefined && val === undefined
+  }
+
+  /** Null */
+  if (<DT> type === DATATYPE.null || val === null) {
+    return <DT> type === DATATYPE.null && val === null
+  }
 
   /** Validate `type` */
   if (!validDataType(type)) {
@@ -142,15 +149,6 @@ export function is (val: any, type: DataType, options?: isOptions): boolean {
     if (<DT> type === DATATYPE.natural) numOptions.min = Math.max(0, numOptions.min)
 
     return is(val, <DT> DATATYPE.number, numOptions)
-  }
-
-  /**
-   * Test for `null`
-   * If it's not allowed, return `false`
-   * If it's allowed, check for `any` or `object`
-   */
-  if (val === null) {
-    return !opts.allowNull ? false : <DT> type === DATATYPE.object
   }
 
   /**

--- a/src/options.ts
+++ b/src/options.ts
@@ -26,12 +26,11 @@ function validSchema (val: any) {
 const toKeyRegex = (arr: (keyof isOptions)[]) => RegExp(`^(${arr.join('|')})$`)
 
 const stringParamRegex = toKeyRegex(['pattern', 'patternFlags'])
-const booleanParamRegex = toKeyRegex(['exclEmpty', 'allowNull', 'arrayAsObject'])
+const booleanParamRegex = toKeyRegex(['exclEmpty', 'arrayAsObject'])
 const numberParamRegex = toKeyRegex(['min', 'max', 'exclMin', 'exclMax', 'multipleOf'])
 
 export class Options implements StrictOptions {
   // from StrictOptionsObject
-  readonly allowNull: boolean = false
   readonly arrayAsObject: boolean = false
   // from StrictOptionsMinMax
   readonly min: number = NEGATIVE_INFINITY

--- a/tools/benchmarks/benchmarks.js
+++ b/tools/benchmarks/benchmarks.js
@@ -21,6 +21,8 @@ function benchmark (version, older, newer) {
     setupTest('Any', 'any', {}),
     setupTest('Undefined (valid)', 'undefined', undefined),
     setupTest('Undefined (invalid)', 'undefined', 'undefined'),
+    setupTest('Null (valid)', 'null', null),
+    setupTest('Null (invalid)', 'null', 'null'),
     setupTest('Boolean (valid)', 'boolean', true),
     setupTest('Boolean (invalid)', 'boolean', 'boolean'),
     setupTest('Number (valid)', 'number', 10),


### PR DESCRIPTION
BREAKING CHANGE
`allowNull` is no longer an option. DataType.object will always return false for `null`. To check for null use `DataType.null`