### PR TITLE
refactor: improve benchmark structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:watch": "nodemon -w src -w tslint.json -e 'ts,js,json' -x 'npm run lint:tslint -- --force'",
     "lint": "npm run lint:tslint",
     "prebenchmark": "npm run clean && npm run build",
-    "benchmark": "node tools/benchmarks/benchmarks.js",
+    "benchmark": "node tools/benchmarks/index.js",
     "pretest": "npm run clean:test",
     "test": "npm run lint && node_modules/.bin/karma start --single-run",
     "pretest:watch": "npm run pretest",

--- a/tools/benchmarks/benchmarks.js
+++ b/tools/benchmarks/benchmarks.js
@@ -127,7 +127,10 @@ class BenchmarkTestCases {
     this._print(color(msg));
   }
 
-  /** Print a message namespaces with the test key */
+  /**
+   * Print a message namespaces with the test key
+   * @param {string} msg
+   */
   _print(msg) {
     console.log(chalk.cyan(`[${this.test.key}]`) + ` ${msg}`);
   }

--- a/tools/benchmarks/benchmarks.js
+++ b/tools/benchmarks/benchmarks.js
@@ -146,4 +146,5 @@ class BenchmarkTestCases {
 }
 
 // RUN
+console.log('\r\nStarting to run tests...\r\n');
 tests.map(t => new BenchmarkTestCases(t, releases)).forEach(t => t.run());

--- a/tools/benchmarks/benchmarks.js
+++ b/tools/benchmarks/benchmarks.js
@@ -36,7 +36,7 @@ class BenchmarkResultRecord {
 }
 
 /**
- *
+ * A record tha reflects a single test case matched to multiple releases
  * @class BenchmarkTestCases
  */
 class BenchmarkTestCases {

--- a/tools/benchmarks/benchmarks.js
+++ b/tools/benchmarks/benchmarks.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const Benchmark = require('benchmark');
-const chalk = require('chalk');
+const chalk = require('chalk').default;
 
 const { releases, currentReleaseName } = require('./releases');
 const { tests } = require('./tests');
@@ -27,11 +27,9 @@ class BenchmarkTestCases {
 
   /** Runs the declared benchmarks */
   run() {
-    const { key, name } = this.test;
     const results = [];
-    const suite = this.suite;
 
-    suite
+    this.suite
       .on('cycle', event => {
         results.push(event);
         this._print(String(event.target));
@@ -45,8 +43,6 @@ class BenchmarkTestCases {
 
   /** Converts set result data into result records */
   getResultRecords() {
-    const resultRecords = [];
-
     return this.results.map(res => {
       const releaseName = res.target.name;
       const release = this.releases.get(releaseName);
@@ -67,7 +63,7 @@ class BenchmarkTestCases {
 
   /** Gets the fastest run's name */
   _getFastest() {
-    return this.suite.filter('fastest').map('name');
+    return this.suite.filter('fastest').map(s => s.name);
   }
 
   /** Returns a percentage-based increase/decrease in performance */
@@ -86,8 +82,9 @@ class BenchmarkTestCases {
       }
     });
 
-    var avg = fast / (+rest / (benchmarks.length - 1)) * 100;
-    return `${Benchmark.formatNumber(avg.toFixed())}%`;
+    let avg = fast / (+rest / (benchmarks.length - 1)) * 100;
+    avg = parseFloat(avg.toFixed());
+    return `${Benchmark.formatNumber(avg)}%`;
   }
 
   /** Prints a message stating the fastest run for this tests */
@@ -103,7 +100,7 @@ class BenchmarkTestCases {
 
   /** Print a message namespaces with the test key */
   _print(msg) {
-    console.log(`[${this.test.key}] ${msg}`);
+    console.log(chalk.cyan(`[${this.test.key}]`) + ` ${msg}`);
   }
 
   /** Converts releases intro an ES2015 Map */

--- a/tools/benchmarks/index.js
+++ b/tools/benchmarks/index.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+const { releases } = require('./releases');
+const { tests } = require('./tests');
+const { BenchmarkTestCases } = require('./benchmarks');
+
+console.log('\r\nStarting to run tests...\r\n');
+tests.map(t => new BenchmarkTestCases(t, releases)).forEach(t => t.run());

--- a/tools/benchmarks/releases.js
+++ b/tools/benchmarks/releases.js
@@ -1,24 +1,47 @@
 // @ts-check
 
-const { gitSha, gitTagsBySha } = require('../utils/git');
+/**
+ * @typedef {Object} IsDataTypeRelease
+ * @property {any} is
+ * @property {any} DataType
+ */
+
+/**
+ * @typedef {Object} BenchmarkReleaseConfig
+ * @property {string} tag - Git tag marking a release
+ * @property {IsDataTypeRelease} lib - isDataType release
+ */
+
+const { gitSha, gitShaByTag } = require('../utils/git');
 
 const currentGitSha = gitSha();
 const currentReleaseName = 'HEAD';
 
-const releases = [
-  {
-    name: 'v0.3.1',
-    sha: 'c6da5dc7afcfbd790103099f1fcd9aeeb962093d',
-    lib: require('./is.func-0-3-1.umd.min')
-  },
-  {
-    name: 'HEAD',
-    sha: currentGitSha,
-    lib: require('../../dist/bundle/isDatatype.umd.min')
+class BenchmarkRelease {
+  /**
+   * Creates an instance of BenchmarkRelease.
+   * @param {BenchmarkReleaseConfig} config
+   */
+  constructor(config) {
+    this.tag = config.tag;
+    this.lib = config.lib;
+    this.sha = this.tag === currentReleaseName ? currentGitSha : gitShaByTag(this.tag);
   }
-].map(r => Object.assign({}, r, { tags: gitTagsBySha(r.sha) }));
+}
+
+const releases = [
+  new BenchmarkRelease({
+    tag: 'v0.3.1',
+    lib: require('./is.func-0-3-1.umd.min')
+  }),
+  new BenchmarkRelease({
+    tag: currentReleaseName,
+    lib: require('../../dist/bundle/isDatatype.umd.min')
+  })
+];
 
 module.exports = {
   releases,
-  currentReleaseName
+  currentReleaseName,
+  BenchmarkRelease
 };

--- a/tools/benchmarks/releases.js
+++ b/tools/benchmarks/releases.js
@@ -1,0 +1,24 @@
+// @ts-check
+
+const { gitSha, gitTagsBySha } = require('../utils/git');
+
+const currentGitSha = gitSha();
+const currentReleaseName = 'HEAD';
+
+const releases = [
+  {
+    name: 'v0.3.1',
+    sha: 'c6da5dc7afcfbd790103099f1fcd9aeeb962093d',
+    lib: require('./is.func-0-3-1.umd.min')
+  },
+  {
+    name: 'HEAD',
+    sha: currentGitSha,
+    lib: require('../../dist/bundle/isDatatype.umd.min')
+  }
+].map(r => Object.assign({}, r, { tags: gitTagsBySha(r.sha) }));
+
+module.exports = {
+  releases,
+  currentReleaseName
+};

--- a/tools/benchmarks/tests.js
+++ b/tools/benchmarks/tests.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+const { toKebabCase } = require('../utils/string');
+
+const tests = [
+  {
+    name: 'Undefined (valid)',
+    dataType: 'undefined',
+    test: undefined
+  },
+  {
+    name: 'Undefined (invalid)',
+    dataType: 'undefined',
+    test: 'undefined'
+  },
+  {
+    name: 'Null (valid)',
+    dataType: 'null',
+    test: null
+  },
+  {
+    name: 'Null (invalid)',
+    dataType: 'null',
+    test: 'null'
+  },
+  {
+    name: 'Boolean (valid)',
+    dataType: 'boolean',
+    test: true
+  },
+  {
+    name: 'Boolean (invalid)',
+    dataType: 'boolean',
+    test: 'boolean'
+  },
+  {
+    name: 'Number (valid)',
+    dataType: 'number',
+    test: 10
+  },
+  {
+    name: 'Number (invalid)',
+    dataType: 'number',
+    test: 'number'
+  },
+  {
+    name: 'Integer (valid)',
+    dataType: 'integer',
+    test: 10
+  },
+  {
+    name: 'Integer (invalid)',
+    dataType: 'integer',
+    test: 'integer'
+  },
+  {
+    name: 'Natural (valid)',
+    dataType: 'natural',
+    test: 10
+  },
+  {
+    name: 'Natural (invalid)',
+    dataType: 'natural',
+    test: 'natural'
+  },
+  {
+    name: 'String (valid)',
+    dataType: 'string',
+    test: 'hello'
+  },
+  {
+    name: 'String (invalid)',
+    dataType: 'string',
+    test: 10
+  },
+  {
+    name: 'Function (valid)',
+    dataType: 'function',
+    test: () => {}
+  },
+  {
+    name: 'Function (invalid)',
+    dataType: 'function',
+    test: 'function'
+  },
+  {
+    name: 'Object (valid)',
+    dataType: 'object',
+    test: {}
+  },
+  {
+    name: 'Object (invalid)',
+    dataType: 'object',
+    test: 'object'
+  },
+  {
+    name: 'Array (valid)',
+    dataType: 'array',
+    test: []
+  },
+  {
+    name: 'Array (invalid)',
+    dataType: 'array',
+    test: 'array'
+  }
+].map(t => Object.assign({}, t, { key: toKebabCase(t.name) }));
+
+module.exports = {
+  tests
+};

--- a/tools/benchmarks/tests.js
+++ b/tools/benchmarks/tests.js
@@ -1,110 +1,136 @@
 // @ts-check
 
+/**
+ * @typedef {Object} BenchmarkTestConfig
+ * @property {string} name - The human-readable name of the test
+ * @property {string} dataType - The data type the test will test for
+ * @property {any} test - The value that will be tested against the dataType
+ */
+
 const { toKebabCase } = require('../utils/string');
 
+class BenchmarkTest {
+  /**
+   * Creates an instance of BenchmarkTest.
+   * @param {BenchmarkTestConfig} config
+   */
+  constructor(config) {
+    this.name = config.name;
+    this.dataType = config.dataType;
+    this.test = config.test;
+    this.key = toKebabCase(this.name);
+  }
+}
+
 const tests = [
-  {
+  new BenchmarkTest({
     name: 'Undefined (valid)',
     dataType: 'undefined',
     test: undefined
-  },
-  {
+  }),
+  new BenchmarkTest({
+    name: 'Undefined (valid)',
+    dataType: 'undefined',
+    test: undefined
+  }),
+  new BenchmarkTest({
     name: 'Undefined (invalid)',
     dataType: 'undefined',
     test: 'undefined'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Null (valid)',
     dataType: 'null',
     test: null
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Null (invalid)',
     dataType: 'null',
     test: 'null'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Boolean (valid)',
     dataType: 'boolean',
     test: true
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Boolean (invalid)',
     dataType: 'boolean',
     test: 'boolean'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Number (valid)',
     dataType: 'number',
     test: 10
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Number (invalid)',
     dataType: 'number',
     test: 'number'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Integer (valid)',
     dataType: 'integer',
     test: 10
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Integer (invalid)',
     dataType: 'integer',
     test: 'integer'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Natural (valid)',
     dataType: 'natural',
     test: 10
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Natural (invalid)',
     dataType: 'natural',
     test: 'natural'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'String (valid)',
     dataType: 'string',
     test: 'hello'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'String (invalid)',
     dataType: 'string',
     test: 10
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Function (valid)',
     dataType: 'function',
     test: () => {}
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Function (invalid)',
     dataType: 'function',
     test: 'function'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Object (valid)',
     dataType: 'object',
     test: {}
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Object (invalid)',
     dataType: 'object',
     test: 'object'
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Array (valid)',
     dataType: 'array',
     test: []
-  },
-  {
+  }),
+  new BenchmarkTest({
     name: 'Array (invalid)',
     dataType: 'array',
     test: 'array'
-  }
-].map(t => Object.assign({}, t, { key: toKebabCase(t.name) }));
+  })
+];
 
 module.exports = {
-  tests
+  tests,
+  BenchmarkTest
 };

--- a/tools/utils/git.js
+++ b/tools/utils/git.js
@@ -1,26 +1,35 @@
- // @ts-check
+// @ts-check
 
 const execSync = require('child_process').execSync;
 
-function gitSha () {
+/**
+ * Returns the git sha for HEAD
+ * @returns {string}
+ */
+function gitSha() {
   return execSync('git rev-parse HEAD')
     .toString()
     .replace(/(\r\n|\n|\r)/gm, '');
 }
 
-function gitTagsBySha (sha) {
-  if (!sha) return [];
+/**
+ * Takes a git tag and returns a git sha (commit hash)
+ * @param {string} tag
+ * @returns {string}
+ */
+function gitShaByTag(tag) {
+  if (!tag) return '';
 
-  const gitTags = execSync(`git tag --list --contains ${sha}`)
+  const sha = execSync(`git rev-list -n 1 ${tag}`)
     .toString()
     .replace(/(\r\n|\n|\r)/gm, '||')
     .split('||')
     .filter(t => !!t);
 
-  return [...new Set(gitTags)];
+  return sha[0];
 }
 
 module.exports = {
   gitSha,
-  gitTagsBySha
-}
+  gitShaByTag
+};

--- a/tools/utils/git.js
+++ b/tools/utils/git.js
@@ -1,0 +1,26 @@
+ // @ts-check
+
+const execSync = require('child_process').execSync;
+
+function gitSha () {
+  return execSync('git rev-parse HEAD')
+    .toString()
+    .replace(/(\r\n|\n|\r)/gm, '');
+}
+
+function gitTagsBySha (sha) {
+  if (!sha) return [];
+
+  const gitTags = execSync(`git tag --list --contains ${sha}`)
+    .toString()
+    .replace(/(\r\n|\n|\r)/gm, '||')
+    .split('||')
+    .filter(t => !!t);
+
+  return [...new Set(gitTags)];
+}
+
+module.exports = {
+  gitSha,
+  gitTagsBySha
+}

--- a/tools/utils/string.js
+++ b/tools/utils/string.js
@@ -1,0 +1,14 @@
+ // @ts-check
+
+function toKebabCase (str) {
+  return typeof str === 'string'
+    ? str.replace(/([\(\)])/g, '')
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .replace(/\s+/g, '-')
+      .toLowerCase()
+    : '';
+}
+
+module.exports = {
+  toKebabCase
+}


### PR DESCRIPTION
Summary:
- Add more structure to benchmarks
- Better reporting at the other end
- Allows for testing multiple releases per test
- Strong type hinting (in-editor, not compile time)

Future work:
- Tie in reporting to a remote source for visualizing/monitoring