### PR TITLE
perf(is): check for single datatype when possible

### DIFF
--- a/spec/isOneOfMultipleTypes.spec.ts
+++ b/spec/isOneOfMultipleTypes.spec.ts
@@ -15,9 +15,7 @@ const invalidTypeValues = [
 
 describe(`isOneOfMultipleTypes`, () => {
   it(`should only take valid \`DataType\` values for the \`type\` argument`, () => {
-    invalidTypeValues.forEach(n =>
-      expect(isOneOfMultipleTypes(true, n as DataType)).toBe(false, `Failed test for ${JSON.stringify(n)}`)
-    )
+    invalidTypeValues.forEach(n => expect(() => isOneOfMultipleTypes(true, n as DataType)).toThrow())
   })
 
   it(`should immediately return \`true\` when \`any\` is passed`, () => {

--- a/src/data-type.ts
+++ b/src/data-type.ts
@@ -43,13 +43,12 @@ export const enum DATATYPE {
  */
 export type DT = DataType & DATATYPE
 
-/**
- * Checks for whether an item is a valid option in the DataType enum
- */
-export function validDataType (val: DataType | DataType[] | undefined): boolean {
-  function check (val: DataType | undefined) {
-    return typeof val === 'number' && val in DataType
-  }
+/** Validates a single DataType */
+export function validDataType (dt: DataType | undefined | null): boolean {
+  return typeof dt === 'number' && dt in DataType
+}
 
-  return Array.isArray(val) ? val.every(check) : check(val)
+/** Validates multiple DataTypes */
+export function validMultiDataType (dt: DataType | DataType[] | undefined | null): boolean {
+  return Array.isArray(dt) ? dt.every(validDataType) : validDataType(dt)
 }

--- a/src/is.ts
+++ b/src/is.ts
@@ -115,6 +115,10 @@ export function is (val: any[], type: DataType, options?: isOptionsArray): boole
 export function is (val: object, type: DataType, options?: isOptionsObject): boolean
 export function is (val: any, type: DataType, options?: isOptions): boolean {
 
+  if (!validDataType(type)) {
+    throw TypeError(`Invalid DataType provided: ${val}`)
+  }
+
   /** Any */
   if (<DT> type === DATATYPE.any) return true
 
@@ -126,11 +130,6 @@ export function is (val: any, type: DataType, options?: isOptions): boolean {
   /** Null */
   if (<DT> type === DATATYPE.null || val === null) {
     return <DT> type === DATATYPE.null && val === null
-  }
-
-  /** Validate `type` */
-  if (!validDataType(type)) {
-    throw Error('Provided invalid `type` argument')
   }
 
   /** Sanitize options object */
@@ -221,12 +220,12 @@ export function is (val: any, type: DataType, options?: isOptions): boolean {
  */
 export function isOneOfMultipleTypes (val: any, type: DataType | DataType[], options?: isOptions): boolean {
   /** Coerce `DataType` into an array and filter out non-`DataType` items */
-  const types = (Array.isArray(type) ? type : [type]).filter(validDataType)
+  const types = Array.isArray(type) ? type : [type]
 
   /**
    * If no length, return false
    * Else if `types` contain any, return true
    * Else test against `is`
    */
-  return types.length > 0 ? types.some(n => is(val, n, options)) : false
+  return types.some(n => is(val, n, options))
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,4 +1,4 @@
-import { DataType, DATATYPE, DT, validDataType } from './data-type'
+import { DataType, DATATYPE, DT, validMultiDataType } from './data-type'
 import { isOptions, isTypeSchema, StrictOptions } from './interfaces'
 import { NEGATIVE_INFINITY, POSITIVE_INFINITY } from './constants'
 import { matchesSchema } from './schema'
@@ -56,7 +56,7 @@ export class Options implements StrictOptions {
       const val = options[<keyof isOptions> k]
       if (this.hasOwnProperty(k) && val !== undefined) {
         if (
-          (<keyof isOptions> k === 'type' && validDataType(<isOptions['type']> val)) ||
+          (<keyof isOptions> k === 'type' && validMultiDataType(<isOptions['type']> val)) ||
           (typeof val === 'string' && stringParamRegex.test(k)) ||
           (typeof val === 'boolean' && booleanParamRegex.test(k)) ||
           (typeof val === 'number' && !isNaN(val) && numberParamRegex.test(k)) ||

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,5 @@
 import { isTypeSchema } from './interfaces'
-import { DATATYPE, DataType, DT, validDataType } from './data-type'
+import { DATATYPE, DataType, DT, validMultiDataType } from './data-type'
 import { isOneOfMultipleTypes } from './is'
 
 /**
@@ -11,7 +11,7 @@ export function matchesSchema (val: any, schema: isTypeSchema | isTypeSchema[]):
   /** Test every schema until at least one of them matches */
   return schemas.some((s: isTypeSchema) => {
     /** If type is defined but invalid, schema is false */
-    if (s.type !== undefined && !validDataType(s.type)) return false
+    if (s.type !== undefined && !validMultiDataType(s.type)) return false
 
     /** Cache the type. Use `any` if none is present */
     const sType: DataType | DataType[] = s.type === undefined ? <DT> DATATYPE.any : s.type

--- a/tools/benchmarks/tests.js
+++ b/tools/benchmarks/tests.js
@@ -29,11 +29,6 @@ const tests = [
     test: undefined
   }),
   new BenchmarkTest({
-    name: 'Undefined (valid)',
-    dataType: 'undefined',
-    test: undefined
-  }),
-  new BenchmarkTest({
     name: 'Undefined (invalid)',
     dataType: 'undefined',
     test: 'undefined'


### PR DESCRIPTION
Slightly lowers the ops/sec for `undefined` and `null` in favor of increasing them for everything else. `undefined` and `null` are expected to decrease because previously there were little-to-no operations before their checks; however, it might not matter in the long term because it's likely that people will much more frequently check against almost any other `DataType`.

Average increase overall: 10%
Average Increase for all except `undefined` and `null`: 16%

| test case         | before (ops/sec) | after (ops/sec) | difference |
|-------------------|------------------|-----------------|------------|
| undefined-valid   | 27,038,957       | 22,871,528      | -15%       |
| undefined-invalid | 27,368,894       | 23,254,362      | -15%       |
| null-valid        | 23,352,353       | 21,140,243      | -9%        |
| null-invalid      | 23,146,336       | 20,407,678      | -12%       |
| boolean-valid     | 12,349,800       | 15,247,814      | 23%        |
| boolean-invalid   | 12,541,613       | 15,214,705      | 21%        |
| number-valid      | 9,100,878        | 9,776,449       | 7%         |
| number-invalid    | 12,997,872       | 15,243,125      | 17%        |
| integer-valid     | 6,800,126        | 8,075,495       | 19%        |
| integer-invalid   | 8,756,741        | 9,561,322       | 9%         |
| natural-valid     | 6,815,298        | 7,726,053       | 13%        |
| natural-invalid   | 8,681,553        | 10,105,690      | 16%        |
| string-valid      | 5,130,817        | 5,234,438       | 2%         |
| string-invalid    | 13,243,061       | 15,311,125      | 16%        |
| function-valid    | 13,123,377       | 14,964,545      | 14%        |
| function-invalid  | 13,097,122       | 15,255,205      | 16%        |
| object-valid      | 12,507,796       | 14,559,489      | 16%        |
| object-invalid    | 12,050,531       | 15,663,236      | 30%        |
| array-valid       | 8,306,534        | 9,062,618       | 9%         |
| array-invalid     | 14,402,991       | 17,273,208      | 20%        |