### PR TITLE
feat: remove options `exclMin` and `exclMax`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ is(-10, DataType.natural); // false
 
 // Using options to affect validation
 is(-10, DataType.number, { min: -10 }); // true
-is(-10, DataType.number, { exclMin: -10 }); // false
 
 // Another example using options
 // Arrays have they're own data type, but can be allowed to be treated as objects, i.e., `typeof [] === 'object'`
@@ -104,8 +103,6 @@ schema: null // Used for `object` and `any` use cases
 arrayAsObject: false // Used for `object` use cases
 min: Number.NEGATIVE_INFINITY // Used for `number` use cases
 max: Number.POSITIVE_INFINITY // Used for `number` use cases
-exclMin: Number.NEGATIVE_INFINITY // Used for `number` use cases
-exclMax: Number.POSITIVE_INFINITY // Used for `number` use cases
 multipleOf: 0 // Used for `number` use cases. `0` means no `multipleOf` check
 ```
 
@@ -118,22 +115,16 @@ Strings have an optional value to exclude empty values by passing `exclEmpty` in
 * `type`: `DataType|DataType[]`
 * `min`: `number`
 * `max`: `number`
-* `exclMin`: `number`
-* `exclMax`: `number`
 
 With the `type` option, arrays can be tested to see whether their values are of a single type or one of multiple types, in which case an array of types needs to be passed into the `type` option. To clarify, this is strictly testing for "one of multiple types"; as long as a single one of the types passed validates as `true`, then `is` will return `true`.
 
-Additionally, arrays can be tested to have a `min`, `max`, `exclMin`, and `exclMax` lengths. `min` and `max` are inclusive in their checks (`>=` and `<=`, respectively), where `exclMin` and `exclMax` are check lengths exclusively (`<` and `>`, respectively).
+Additionally, arrays can be tested to have `min` and `max` lengths. `min` and `max` are inclusive in their checks.
 
 #### Number options
 
 * `min`: `number`
 * `max`: `number`
-* `exclMin`: `number`
-* `exclMax`: `number`
 * `multipleOf`: `number`
-
-As with Arrays, `exclMin` and `exclMax` are exclusive variants of `min` and `max` with the exception of negative and positive infinity.
 
 `multipleOf` will check whether the number being evaluated is a multiple of the value in this option. Please note that when negative and positive infinities are used as the value to test for, the use of `multipleOf` will result in `false` because using Infinity on the left side of modulus is `NaN`.
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clean:test": "node_modules/.bin/rimraf coverage",
     "clean:dist": "node_modules/.bin/rimraf dist",
     "clean": "npm run clean:test & npm run clean:dist",
-    "dev": "npm run clean:dist && nodemon --watch 'src' -e 'ts' -x 'node_modules/.bin/tsc'",
+    "dev": "npm run clean:dist && node_modules/.bin/tsc --watch",
     "prebuild": "npm run clean:dist",
     "build:compile": "node_modules/.bin/tsc",
     "build:bundle": "node_modules/.bin/webpack --env.min && node_modules/.bin/webpack",

--- a/spec/is.spec.ts
+++ b/spec/is.spec.ts
@@ -480,20 +480,6 @@ describe('`is` and `matchesSchema`', () => {
       expect(() => is(100, DataType.number, { max: NaN })).toThrow();
     });
 
-    it('should detect invalid values assigned to `exclMin`', () => {
-      expect(() => is(100, DataType.number, { exclMin: undefined })).not.toThrow();
-      expect(() => is(100, DataType.number, { exclMin: 0 })).not.toThrow();
-      expect(() => is(100, DataType.number, { exclMin: '0' } as any)).toThrow();
-      expect(() => is(100, DataType.number, { exclMin: NaN })).toThrow();
-    });
-
-    it('should detect invalid values assigned to `exclMax`', () => {
-      expect(() => is(100, DataType.number, { exclMax: undefined })).not.toThrow();
-      expect(() => is(100, DataType.number, { exclMax: 0 })).not.toThrow();
-      expect(() => is(100, DataType.number, { exclMax: '0' } as any)).toThrow();
-      expect(() => is(100, DataType.number, { exclMax: NaN })).toThrow();
-    });
-
     it('should detect invalid values assigned to `multipleOf`', () => {
       expect(() => is(100, DataType.number, { multipleOf: undefined })).not.toThrow();
       expect(() => is(100, DataType.number, { multipleOf: 0 })).not.toThrow();

--- a/spec/test-cases/non-schema.spec.ts
+++ b/spec/test-cases/non-schema.spec.ts
@@ -21,84 +21,41 @@ export const validNumberNegativeUseCases = [
 export const invalidNumberUseCases = [NaN, Number.NaN];
 
 export const numberRangeUseCases = [
-  // `max` and `exclMax` tests against 0
+  // `max` tests against 0
   { test: 0, options: { max: 0 }, expect: true },
   { test: -1, options: { max: 0 }, expect: true },
   { test: 1, options: { max: 0 }, expect: false },
-  { test: 0, options: { exclMax: 0 }, expect: false },
-  { test: -1, options: { exclMax: 0 }, expect: true },
-  { test: 1, options: { exclMax: 0 }, expect: false },
-  { test: 0, options: { max: 0, exclMax: 0 }, expect: false },
-  { test: -1, options: { max: 0, exclMax: 0 }, expect: true },
-  { test: 1, options: { max: 0, exclMax: 0 }, expect: false },
 
-  // `max` and `exclMax` tests against -1 and 1
+  // `max` tests against -1 and 1
   { test: -1, options: { max: -1 }, expect: true },
   { test: 1, options: { max: 1 }, expect: true },
-  { test: -1, options: { exclMax: -1 }, expect: false },
-  { test: 1, options: { exclMax: 1 }, expect: false },
-  { test: -1, options: { max: -1, exclMax: -1 }, expect: false },
-  { test: 1, options: { max: 1, exclMax: 1 }, expect: false },
 
-  // `min` and `exclMin` tests against 0
+  // `min` tests against 0
   { test: 0, options: { min: 0 }, expect: true },
   { test: -1, options: { min: 0 }, expect: false },
   { test: 1, options: { min: 0 }, expect: true },
-  { test: 0, options: { exclMin: 0 }, expect: false },
-  { test: -1, options: { exclMin: 0 }, expect: false },
-  { test: 1, options: { exclMin: 0 }, expect: true },
-  { test: 0, options: { min: 0, exclMin: 0 }, expect: false },
-  { test: -1, options: { min: 0, exclMin: 0 }, expect: false },
-  { test: 1, options: { min: 0, exclMin: 0 }, expect: true },
 
-  // `min` and `exclMin` tests against -1 and 1
+  // `min` tests against -1 and 1
   { test: -1, options: { min: -1 }, expect: true },
   { test: 1, options: { min: 1 }, expect: true },
-  { test: -1, options: { exclMin: -1 }, expect: false },
-  { test: 1, options: { exclMin: 1 }, expect: false },
-  { test: -1, options: { min: -1, exclMin: -1 }, expect: false },
-  { test: 1, options: { min: 1, exclMin: 1 }, expect: false },
 
-  // `max` and `exclMax` tests against -3.14
+  // `max` tests against -3.14
   { test: -3.14, options: { max: -3.14 }, expect: true },
   { test: -3.15, options: { max: -3.14 }, expect: true },
   { test: -3.13, options: { max: -3.14 }, expect: false },
-  { test: -3.14, options: { exclMax: -3.14 }, expect: false },
-  { test: -3.15, options: { exclMax: -3.14 }, expect: true },
-  { test: -3.13, options: { exclMax: -3.14 }, expect: false },
-  { test: -3.14, options: { max: -3.14, exclMax: -3.14 }, expect: false },
-  { test: -3.15, options: { max: -3.14, exclMax: -3.14 }, expect: true },
-  { test: -3.13, options: { max: -3.14, exclMax: -3.14 }, expect: false },
 
-  // `max` and `exclMax` tests against -3.15 and -3.13
+  // `max` tests against -3.15 and -3.13
   { test: -3.15, options: { max: -3.15 }, expect: true },
   { test: -3.13, options: { max: -3.13 }, expect: true },
-  { test: -3.15, options: { exclMax: -3.15 }, expect: false },
-  { test: -3.13, options: { exclMax: -3.13 }, expect: false },
-  { test: -3.15, options: { max: -3.15, exclMax: -3.15 }, expect: false },
-  { test: -3.13, options: { max: -3.13, exclMax: -3.13 }, expect: false },
 
-  // `min` and `exclMin` tests against -3.14
+  // `min` tests against -3.14
   { test: -3.14, options: { min: -3.14 }, expect: true },
   { test: -3.15, options: { min: -3.14 }, expect: false },
   { test: -3.13, options: { min: -3.14 }, expect: true },
-  { test: -3.14, options: { exclMin: -3.14 }, expect: false },
-  { test: -3.15, options: { exclMin: -3.14 }, expect: false },
-  { test: -3.13, options: { exclMin: -3.14 }, expect: true },
-  { test: -3.14, options: { min: -3.14, exclMin: -3.14 }, expect: false },
-  { test: -3.15, options: { min: -3.14, exclMin: -3.14 }, expect: false },
-  { test: -3.13, options: { min: -3.14, exclMin: -3.14 }, expect: true },
 
-  // `min` and `exclMin` tests against -3.15 and -3.13
+  // `min` tests against -3.15 and -3.13
   { test: -3.15, options: { min: -3.15 }, expect: true },
-  { test: -3.13, options: { min: -3.13 }, expect: true },
-  { test: -3.15, options: { exclMin: -3.15 }, expect: false },
-  { test: -3.13, options: { exclMin: -3.13 }, expect: false },
-  { test: -3.15, options: { min: -3.15, exclMin: -3.15 }, expect: false },
-  { test: -3.13, options: { min: -3.13, exclMin: -3.13 }, expect: false },
-
-  // With inconsequential option
-  { test: -3.13, options: { min: -3.13, exclMin: -3.13, someOtherProp: true }, expect: false }
+  { test: -3.13, options: { min: -3.13 }, expect: true }
 ];
 
 export const multipleOfUseCases = [
@@ -117,10 +74,7 @@ export const multipleOfUseCases = [
   { test: -2, options: { multipleOf: -2 }, expect: true },
   { test: 6.28, options: { multipleOf: 3.14 }, expect: true },
   { test: -6.28, options: { multipleOf: 3.14 }, expect: true },
-  { test: 6.28, options: { multipleOf: -3.14 }, expect: true },
-
-  // With inconsequential option
-  { test: 6.28, options: { multipleOf: -3.14, someOtherProp: true }, expect: true }
+  { test: 6.28, options: { multipleOf: -3.14 }, expect: true }
 ];
 
 export const integerUseCases = [
@@ -139,10 +93,7 @@ export const integerUseCases = [
   { test: -2048, options: { multipleOf: -512 }, expect: true },
   { test: 3.14, options: { multipleOf: 2 }, expect: false },
   { test: Math.sqrt(2), options: { multipleOf: 2 }, expect: false },
-  { test: 3.14, options: { multipleOf: 3.14 }, expect: false },
-
-  // With inconsequential option
-  { test: 3.14, options: { multipleOf: 3.14, someOtherProp: true }, expect: false }
+  { test: 3.14, options: { multipleOf: 3.14 }, expect: false }
 ];
 
 export const naturalUseCases = [
@@ -167,12 +118,7 @@ export const naturalUseCases = [
   { test: 21, options: { min: 22 }, expect: false },
   { test: 4, options: { max: 5 }, expect: true },
   { test: 4, options: { max: 3 }, expect: false },
-  { test: 0, options: { max: 0 }, expect: true },
-  { test: 0, options: { exclMin: 0 }, expect: false },
-  { test: 0, options: { exclMax: 0 }, expect: false },
-
-  // With inconsequential option
-  { test: 0, options: { exclMax: 0, someOtherProp: true }, expect: false }
+  { test: 0, options: { max: 0 }, expect: true }
 ];
 
 export const validStringUseCases = [
@@ -190,10 +136,7 @@ export const stringPatternUseCases = [
   { test: 'hello world!', options: { pattern: 'world', patternFlags: 'g' }, expect: true },
   { test: 'HELLO WORLD!', options: { pattern: 'world' }, expect: false },
   { test: 'HELLO WORLD!', options: { pattern: 'world', patternFlags: 'i' }, expect: true },
-  { test: 'John Smith', options: { pattern: '(\\w+)\\s(\\w+)' }, expect: true },
-
-  // With inconsequential option
-  { test: 'John Smith', options: { pattern: '(\\w+)\\s(\\w+)', someOtherProp: true }, expect: true }
+  { test: 'John Smith', options: { pattern: '(\\w+)\\s(\\w+)' }, expect: true }
 ];
 
 export const validBooleanUseCases = [true, false, Boolean(true)];
@@ -204,10 +147,7 @@ export const validArrayUseCases = [
   { test: [() => {}], options: { type: DataType.function } },
   { test: [{ a: 1 }, {}], options: { type: DataType.object } },
   { test: ['1', '2', '4'], options: { type: DataType.string } },
-  { test: [[1], [2], [4]], options: { type: DataType.array } },
-
-  // With inconsequential option
-  { test: [[1], [2], [4]], options: { type: DataType.array, someOtherProp: true } }
+  { test: [[1], [2], [4]], options: { type: DataType.array } }
 ];
 
 export const arrayWithOptionsUseCases = [
@@ -232,26 +172,14 @@ export const arrayWithOptionsUseCases = [
   { test: [1], options: { min: 2 }, expect: false },
   { test: [1, 2], options: { min: 2 }, expect: true },
   { test: [1, 2], options: { max: 2 }, expect: true },
-  { test: [1, 2, 3], options: { max: 2 }, expect: false },
-  { test: [1, 2, 3], options: { exclMax: 3 }, expect: false },
-  { test: [1, 2], options: { exclMax: 3 }, expect: true },
-  { test: [1, 2, 3], options: { exclMin: 3 }, expect: false },
-  { test: [1, 2, 3, 4], options: { exclMin: 3 }, expect: true },
-
-  // With inconsequential option
-  { test: [1, 2, 3, 4], options: { exclMin: 3, someOtherProp: true }, expect: true }
+  { test: [1, 2, 3], options: { max: 2 }, expect: false }
 ];
 
 export const validFunctionUseCases = [function() {}, class C {}, Math.sin];
 
 export const validObjectUseCases = [{ a: 1 }, {}];
 
-export const optionalObjectUseCases = [
-  { test: [], options: { arrayAsObject: true } },
-
-  // With inconsequential option
-  { test: [], options: { arrayAsObject: true, someOtherProp: true } }
-];
+export const optionalObjectUseCases = [{ test: [], options: { arrayAsObject: true } }];
 
 export const validNullUseCases = [null];
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -72,6 +72,4 @@ export type isOptionsMinMax = Partial<StrictOptionsMinMax>;
 export interface StrictOptionsMinMax {
   min: number;
   max: number;
-  exclMin: number;
-  exclMax: number;
 }

--- a/src/is.ts
+++ b/src/is.ts
@@ -50,8 +50,6 @@ import { Options } from './options';
  * arrayAsObject: false // Used for `object` use cases
  * min: Number.NEGATIVE_INFINITY // Used for `number` use cases
  * max: Number.POSITIVE_INFINITY // Used for `number` use cases
- * exclMin: Number.NEGATIVE_INFINITY // Used for `number` use cases
- * exclMax: Number.POSITIVE_INFINITY // Used for `number` use cases
  * multipleOf: 0 // Used for `number` use cases. `0` means no `multipleOf` check
  * ```
  *
@@ -65,8 +63,6 @@ import { Options } from './options';
  * * `type`: `DataType|Array<DataType>`
  * * `min`: `number`
  * * `max`: `number`
- * * `exclMin`: `number`
- * * `exclMax`: `number`
  *
  * With the `type` option, arrays can be tested to see whether their
  * values are of a single type or one of multiple types, in which case
@@ -75,21 +71,14 @@ import { Options } from './options';
  * as long as a single one of the types passed validates as `true`,
  * then `is` will return `true`.
  *
- * Additionally, arrays can be tested to have a `min`, `max`, `exclMin`,
- * and `exclMax` lengths. `min` and `max` are inclusive in their checks
- * (`>=` and `<=`, respectively), where `exclMin` and `exclMax` are check
- * lengths exclusively (`<` and `>`, respectively).
+ * Additionally, arrays can be tested to have `min` and `max` lengths.
+ * `min` and `max` are inclusive in their checks.
  *
  * ### Number options
  *
  * * `min`: `number`
  * * `max`: `number`
- * * `exclMin`: `number`
- * * `exclMax`: `number`
  * * `multipleOf`: `number`
- *
- * As with Arrays, `exclMin` and `exclMax` are exclusive variants of
- * `min` and `max` with the exception of negative and positive infinity.
  *
  * `multipleOf` will check whether the number being evaluated is a
  * multiple of the value in this option. Please note that when negative
@@ -184,7 +173,7 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
     return (
       (val as any[]).every(n => isOneOfMultipleTypes(n, opts.type)) &&
       (opts.schema === null || matchesSchema(val, opts.schema)) &&
-      testNumberWithinBounds((val as any[]).length, opts.min, opts.max, opts.exclMin, opts.exclMax)
+      testNumberWithinBounds((val as any[]).length, opts.min, opts.max)
     );
   }
 
@@ -199,16 +188,11 @@ export function is(val: any, type: DataType, options?: isOptions): boolean {
 
   /**
    * If type is `number` check against it's optional values.
-   * If `exclMin` won't exclude Number.NEGATIVE_INFINITY.
-   * If `exclMax` won't exclude Number.POSITIVE_INFINITY.
    * `multipleOf` will only be checked when different than 0.
    * When val is either negative or positive Infinity, `multipleOf` will be false.
    */
   if (<DT>type === DATATYPE.number) {
-    return (
-      testNumberWithinBounds(val, opts.min, opts.max, opts.exclMin, opts.exclMax) &&
-      isMultipleOf(val, opts.multipleOf)
-    );
+    return testNumberWithinBounds(val, opts.min, opts.max) && isMultipleOf(val, opts.multipleOf);
   }
 
   /** All checks passed. */

--- a/src/number-helpers.ts
+++ b/src/number-helpers.ts
@@ -1,5 +1,3 @@
-import { NEGATIVE_INFINITY, POSITIVE_INFINITY } from './constants';
-
 /**
  * Tests whether a number is multiple of another number.
  * Keep in mind that Infinity, positive or negative, would return
@@ -30,15 +28,7 @@ export function isMultipleOf(val: number | undefined, multipleOf: number | undef
 export function testNumberWithinBounds(
   val: number,
   min: number | undefined,
-  max: number | undefined,
-  exclMin: number | undefined,
-  exclMax: number | undefined
+  max: number | undefined
 ): boolean {
-  return (
-    min !== undefined &&
-    val >= min &&
-    (max !== undefined && val <= max) &&
-    (exclMin === NEGATIVE_INFINITY || (exclMin !== undefined && val > exclMin)) &&
-    (exclMax === POSITIVE_INFINITY || (exclMax !== undefined && val < exclMax))
-  );
+  return min !== undefined && val >= min && (max !== undefined && val <= max);
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -30,7 +30,7 @@ const toKeyRegex = (arr: (keyof isOptions)[]) => RegExp(`^(${arr.join('|')})$`);
 
 const stringParamRegex = toKeyRegex(['pattern', 'patternFlags']);
 const booleanParamRegex = toKeyRegex(['exclEmpty', 'arrayAsObject']);
-const numberParamRegex = toKeyRegex(['min', 'max', 'exclMin', 'exclMax', 'multipleOf']);
+const numberParamRegex = toKeyRegex(['min', 'max', 'multipleOf']);
 
 export class Options implements StrictOptions {
   // from StrictOptionsObject
@@ -38,8 +38,6 @@ export class Options implements StrictOptions {
   // from StrictOptionsMinMax
   readonly min: number = NEGATIVE_INFINITY;
   readonly max: number = POSITIVE_INFINITY;
-  readonly exclMin: number = NEGATIVE_INFINITY;
-  readonly exclMax: number = POSITIVE_INFINITY;
   // from StrictOptionsNumber
   readonly multipleOf: number = 0;
   // from StrictOptionsString


### PR DESCRIPTION
BREAKING CHANGE

Removes `exclMin` and `exclMax` as they add complexity to the options while their functionality easily be achieved by `min` and `max`.

Closes #135.