### PR TITLE
fix(multipleof): validate value is number

### DIFF
--- a/spec/isMultipleOf.spec.ts
+++ b/spec/isMultipleOf.spec.ts
@@ -1,0 +1,33 @@
+import { DataType } from '../src/data-type';
+import { isMultipleOf } from '../src/number-helpers';
+import {
+  getDataTypeUseCases,
+  multipleOfUseCases,
+  validNumberNegativeUseCases,
+  validNumberUseCases
+} from './test-cases/test-cases.spec';
+
+describe('isMultipleOf', () => {
+  it('should take any numeric value as multiple of 0', () => {
+    [...validNumberNegativeUseCases, ...validNumberUseCases].forEach(v => {
+      expect(isMultipleOf(v, 0)).toBe(true);
+    });
+  });
+
+  it('should pass multipleOf test cases on its own', () => {
+    multipleOfUseCases.forEach(({ test, options, expect: expectation }) => {
+      expect(isMultipleOf(test, options.multipleOf)).toBe(expectation);
+    });
+  });
+
+  it('should take any non-number value', () => {
+    getDataTypeUseCases(DataType.number).forEach(v => {
+      expect(isMultipleOf(v, 1)).toBe(false);
+      expect(isMultipleOf(v, 0)).toBe(false);
+      expect(isMultipleOf(v, Infinity)).toBe(false);
+      expect(isMultipleOf(v, -Infinity)).toBe(false);
+      expect(isMultipleOf(v, Number.POSITIVE_INFINITY)).toBe(false);
+      expect(isMultipleOf(v, Number.NEGATIVE_INFINITY)).toBe(false);
+    });
+  });
+});

--- a/src/number-helpers.ts
+++ b/src/number-helpers.ts
@@ -5,20 +5,14 @@
  */
 export function isMultipleOf(val: number | undefined, multipleOf: number | undefined): boolean {
   return (
-    multipleOf === 0 ||
-    (typeof val === 'number' &&
-      /**
-       * The modulus operator here excludes both infinities, i.e.,
-       * isNaN(Infinity % 1) === true
-       */
-      !isNaN(val % 1) &&
-      /**
-       * `Math.abs` avoids `-0`
-       * The non-null assertion below is okay because we're
-       * strictly checking for the remainder to be zero
-       */
-      // tslint:disable-next-line no-non-null-assertion
-      Math.abs(val % multipleOf!) === 0)
+    // First, Check that val is a number
+    typeof val === 'number' &&
+    // A few things going on here:
+    // * OK if multipleOf is 0; all numbers are multiples of zero, i.e., x * 0 === 0
+    // * isNaN check uses modulus operator to exclude infinities, i.e., isNaN(Infinity % 1) === true
+    // * Math.abs` avoids `-0`
+    // tslint:disable-next-line no-non-null-assertion
+    (multipleOf === 0 || (!isNaN(val % 1) && Math.abs(val % multipleOf!) === 0))
   );
 }
 


### PR DESCRIPTION
Checks for value to be a number within `isMultipleOf`. This makes this function stand on its own as far as validation.